### PR TITLE
Avoid showing output on each message #106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.8
 
+- Fix regression preventing to use Commands to deploy integration
+
 ## 0.0.7
 
 - Update to naming approved by Red Hat legal

--- a/src/CamelKJSONUtils.ts
+++ b/src/CamelKJSONUtils.ts
@@ -145,7 +145,6 @@ export async function pingKamel() : Promise<any> {
 
 export function shareMessage(outputChannel: vscode.OutputChannel, msg:string) {
 	if (outputChannel) {
-		outputChannel.show();
 		outputChannel.append(msg + '\n');
 	} else {
 		console.log('[' + msg + ']');


### PR DESCRIPTION
it introduced a regression to use the Start integration command palette

also, if a user has hidden or closed the output panel, he/she doesn't
want to have the output popping on each information/trace message

Signed-off-by: Aurélien Pupier <apupier@redhat.com>