### PR TITLE
Add support for starting integrations with YAML file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 - Add ability to deploy integrations associated with Resource files
 - Added the Microsoft Kubernetes Tools extension as an extension dependency
 - Update to add Dev Mode option for quick deployment and instant feedback in the Apache Camel K Output Channel
+- Added support for starting integrations with the YAML file extension
 
 ## 0.0.8
 - Fix regression preventing to use Commands to deploy integration

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 			"explorer/context": [
 				{
 					"command": "camelk.startintegration",
-					"when": "resourceExtname =~ /\\.(groovy|java|xml|js|kts)$/",
+					"when": "resourceExtname =~ /\\.(groovy|java|xml|js|kts|yaml)$/",
 					"group": "camelk.group"
 				},
 				{


### PR DESCRIPTION
fixes #112

I didn't find a simple way of implementing an automated way of testing this, so I tested manually against a local cluster and it works nicely.