### PR TITLE
FUSETOOLS2-81 - support pure Java language with standalone Camel K Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.11
 
-- TBD
+- Pure Java language support with standalone Camel K Java files (requires vscode-java 0.55.0 and that the file contains the word `camel`)
 
 ## 0.0.10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -915,7 +915,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -1035,7 +1034,6 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
             "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
-            "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
@@ -1053,7 +1051,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -1272,8 +1269,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -1379,7 +1375,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -1398,8 +1393,7 @@
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-            "dev": true
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
         },
         "has-to-string-tag-x": {
             "version": "1.4.1",
@@ -1530,14 +1524,12 @@
         "is-callable": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-            "dev": true
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
         },
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -1579,7 +1571,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
             "requires": {
                 "has": "^1.0.1"
             }
@@ -1598,7 +1589,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
             }
@@ -2086,6 +2076,37 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
+        "mvn-artifact-download": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mvn-artifact-download/-/mvn-artifact-download-4.1.0.tgz",
+            "integrity": "sha512-XSraSr/K677Ckvz12D3q2VBecK6SrMzj/BoXYs9kCQ+x1I+A9TkRL/GcX+nPU/JO59GZJdFu5kQzsfRkYMPfyg==",
+            "requires": {
+                "mvn-artifact-filename": "^4.1.0",
+                "mvn-artifact-name-parser": "^4.1.0",
+                "mvn-artifact-url": "^4.1.0",
+                "node-fetch": "^2.6.0"
+            }
+        },
+        "mvn-artifact-filename": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mvn-artifact-filename/-/mvn-artifact-filename-4.1.0.tgz",
+            "integrity": "sha512-n8NB190oYqH2OUfkipLbmv4mfrk3Dkl/8kYZt9BZ4/fiN7OCYtcYJIQB3V6I0crrZqAg3KkTGU5+goukQQ12Hg=="
+        },
+        "mvn-artifact-name-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mvn-artifact-name-parser/-/mvn-artifact-name-parser-4.1.0.tgz",
+            "integrity": "sha512-xoDLl6ryE3v5LuXt+sDb326+0DUkAF5YcXvdr6rvyU3miD2UbY7uOkI9BQaRbmW77Lfuq8ZwGibqyc5e+Q9uWQ=="
+        },
+        "mvn-artifact-url": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mvn-artifact-url/-/mvn-artifact-url-4.1.0.tgz",
+            "integrity": "sha512-cF6xOBjKF+Z05l8tvyNbpUFENPbFTtBSMEDP8tzzecH7TmuH8qRaGxraBlsCS+OuAVtsHGdWNpJl9xTn3nfBuw==",
+            "requires": {
+                "mvn-artifact-filename": "^4.1.0",
+                "node-fetch": "^2.6.0",
+                "xml2js": "^0.4.22"
+            }
+        },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2145,6 +2166,11 @@
                 "object.getownpropertydescriptors": "^2.0.3",
                 "semver": "^5.7.0"
             }
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-key-sender": {
             "version": "1.0.11",
@@ -2232,14 +2258,12 @@
         "object-inspect": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-            "dev": true
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
         },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object.assign": {
             "version": "4.1.0",
@@ -2257,7 +2281,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.5.1"
@@ -2646,8 +2669,7 @@
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "seek-bzip": {
             "version": "1.0.5",
@@ -2867,7 +2889,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
             "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
                 "function-bind": "^1.1.1"
@@ -2877,7 +2898,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
             "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
                 "function-bind": "^1.1.1"
@@ -3232,7 +3252,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "object.getownpropertydescriptors": "^2.0.3"
@@ -3422,7 +3441,6 @@
             "version": "0.4.22",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
             "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
-            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "util.promisify": "~1.0.0",
@@ -3432,8 +3450,7 @@
         "xmlbuilder": {
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "dev": true
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
 		"@types/tmp": "^0.1.0",
 		"child_process": "^1.0.2",
 		"download": "^7.1.0",
+		"mvn-artifact-download": "4.1.0",
 		"path": "^0.12.7",
 		"request": "^2.88.0",
 		"request-promise": "^4.2.5",

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import mvndownload from 'mvn-artifact-download';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES = "java.project.referencedLibraries";
+
+export function downloadJavaDependencies(extensionStorage:string): string {
+    let camelVersion = "3.0.0-RC3";
+    let destination = path.join(extensionStorage, `java-dependencies-${camelVersion}`);
+    /* These are camel-core-engine dependencies, to improve:
+    * - use a dependency manager so we just need to specify camel-core-engine
+    * - rely on kamel inspect to know all extra potential libraries that can be provided
+    */
+    mvndownload(`org.apache.camel:camel-api:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-base:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-core-engine:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-jaxp:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:spi-annotations:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-management-api:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-support:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-util:${camelVersion}`, destination);
+    mvndownload(`org.apache.camel:camel-util-json:${camelVersion}`, destination);
+    mvndownload(`org.slf4j:slf4j-api:1.7.28`, destination);
+    return destination;
+}
+
+export function updateReferenceLibraries(editor: vscode.TextEditor | undefined, destination:string) {
+    const camelKReferencedLibrariesPattern = destination + '/*.jar';
+    let documentEdited = editor?.document;
+    if (documentEdited?.fileName.endsWith(".java")) {
+        let text = documentEdited.getText();
+        const configuration = vscode.workspace.getConfiguration();
+        let refLibrariesConfig = configuration.get(PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES) as Array<string>;
+        if (text.includes("camel")) {
+            ensureReferencedLibrariesContainsCamelK(refLibrariesConfig, camelKReferencedLibrariesPattern, configuration);
+        } else if (refLibrariesConfig.includes(camelKReferencedLibrariesPattern)) {
+            removeCamelKFromReferencedlibraries(refLibrariesConfig, camelKReferencedLibrariesPattern, configuration);
+        }
+    }
+}
+
+function removeCamelKFromReferencedlibraries(refLibrariesConfig: string[], camelKReferencedLibrariesPattern: string, configuration: vscode.WorkspaceConfiguration) {
+    for (var i = 0; i < refLibrariesConfig.length; i++) {
+        if (refLibrariesConfig[i] === camelKReferencedLibrariesPattern) {
+            refLibrariesConfig.splice(i, 1);
+        }
+    }
+    configuration.update(PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES, refLibrariesConfig);
+}
+
+function ensureReferencedLibrariesContainsCamelK(refLibrariesConfig: string[], camelKReferencedLibrariesPattern: string, configuration: vscode.WorkspaceConfiguration) {
+    if (!refLibrariesConfig.includes(camelKReferencedLibrariesPattern)) {
+        refLibrariesConfig.push(camelKReferencedLibrariesPattern);
+        configuration.update(PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES, refLibrariesConfig);
+    }
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import * as kubectl from './kubectl';
 import * as kamel from './kamel';
 import * as kubectlutils from './kubectlutils';
 import * as config from './config';
+import { downloadJavaDependencies, updateReferenceLibraries } from './JavaDependenciesManager';
 
 export let mainOutputChannel: vscode.OutputChannel;
 export let myStatusBarItem: vscode.StatusBarItem;
@@ -134,8 +135,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	
 	});
 
-
+	let destination = downloadJavaDependencies(context.globalStoragePath);
+	
+	vscode.window.onDidChangeActiveTextEditor((editor) => {
+		updateReferenceLibraries(editor, destination);
+	});
+	
+	if (vscode.window.activeTextEditor) {
+		updateReferenceLibraries(vscode.window.activeTextEditor, destination);
+	}
+	
 }
+
 
 export function setStatusLineMessageAndShow( message: string): void {
 	if (myStatusBarItem && message && showStatusBar) {


### PR DESCRIPTION
files

- the Camel K files requires to contain "camel" inside it (same
constraint to have Camel URI support)
- currently providing dependencies only from camel-core-engine. Camel K
can pull some other dependencies but needs some work on kamel inspect to
leverage that
- not smart dependencies declaration all artifacts are hardcoded which
will make it hard to maintain on the long-run but should be fine for a
first iteration

/!\ it requires vscode-java 0.55.0 https://download.jboss.org/jbosstools/jdt.ls/staging/?C=M;O=D (planned to be released on the 23rd December)

will need to think mor eon it but I think that the best to test it is to write a UI test checking for completion. I will surely delegate to QE in this case.

![Screenshot from 2019-12-20 14-10-56](https://user-images.githubusercontent.com/1105127/71256927-95fdda00-2332-11ea-9130-19fd93c166d7.png)
