### PR TITLE
FUSETOOLS-80 - fix archive artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ node('rhel7'){
                 def vsix = findFiles(glob: '**.vsix')
                 sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
             }
-            archive includes:"**.vsix","**.tgz"
+            archiveArtifacts artifacts:"**.vsix,**.tgz"
 
             stage "Promote the build to stable"
             def vsix = findFiles(glob: '**.vsix')


### PR DESCRIPTION
- use list notation inside quotes
- use non-deprecated `archiveArtifacts` instead of deprecated `archive`

same modification than camel-tooling/camel-lsp-client-vscode#233 (but without changelog as no need of a specific release for that, I would prefer to avoid bothering end user with that)