### PR TITLE
FUSETOOLS2-197 - escape spaces in path

### DIFF
--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -43,7 +43,7 @@ export function downloadJavaDependencies(extensionStorage:string): string {
 }
 
 export function updateReferenceLibraries(editor: vscode.TextEditor | undefined, destination:string) {
-    const camelKReferencedLibrariesPattern = destination + '/*.jar';
+    const camelKReferencedLibrariesPattern = escapeSpaces(destination) + '/*.jar';
     let documentEdited = editor?.document;
     if (documentEdited?.fileName.endsWith(".java")) {
         let text = documentEdited.getText();
@@ -57,6 +57,10 @@ export function updateReferenceLibraries(editor: vscode.TextEditor | undefined, 
             updateReferenceLibrariesForConfigKey(text, refLibrariesIncludeConfig, camelKReferencedLibrariesPattern, configuration, includepropertyKeyConfig);
         }
     }
+}
+
+export function escapeSpaces(destination: string) {
+    return destination.replace(/\s/g, '\\ ');
 }
 
 function updateReferenceLibrariesForConfigKey(text: string, refLibrariesConfig: string[], camelKReferencedLibrariesPattern: string, configuration: vscode.WorkspaceConfiguration, configurationKey: string) {

--- a/src/test/suite/javaDependenciesManager.test.ts
+++ b/src/test/suite/javaDependenciesManager.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as javaDependenciesManager from '../../JavaDependenciesManager';
+import * as assert from 'assert';
+
+suite('Escape spaces test', () => {
+
+	test('escape with single space', () => {
+        let escapedValue = javaDependenciesManager.escapeSpaces("/with space");
+        assert.equal(escapedValue, '/with\\ space');
+    });
+    
+    test('escape with several spaces', () => {
+        let escapedValue = javaDependenciesManager.escapeSpaces("/with several spaces");
+        assert.equal(escapedValue, '/with\\ several\\ spaces');
+    });
+    
+    test('escape without space', () => {
+        let escapedValue = javaDependenciesManager.escapeSpaces("/withoutspace");
+        assert.equal(escapedValue, '/withoutspace');
+    });
+
+});


### PR DESCRIPTION
as java extension requires it.
Java extension is using glob but cannot found a library that is covering
all possible escaped characters so doing it for the only one that is
spotted for now. This use case is the default on Mac OS.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>