### PR TITLE
FUSETOOLS2-205 - avoid infinite loop when no Kubernetes instance

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	
 		// add commands to create config-map and secret objects from .properties files
 		configmapsandsecrets.registerCommands();
-	
+		
 	});
 
 	let destination = downloadJavaDependencies(context);
@@ -298,12 +298,13 @@ export async function getIntegrationsFromKubectlCliWithWatch() : Promise<void> {
 						}
 					});
 				}
-				runKubectl.on("close", (close) => {
+				runKubectl.on("close", () => {
 					if (camelKIntegrationsTreeView.visible === true) {
 						// stopped listening to server - likely timed out
 						eventEmitter.emit(restartKubectlWatchEvent);
 					}
 					runningKubectl = undefined;
+					resolve();
 				});				
 			})
 			.catch( (error) => {
@@ -314,7 +315,7 @@ export async function getIntegrationsFromKubectlCliWithWatch() : Promise<void> {
 }
 
 // use kubectl to keep an eye on the server for changes and update the view
-async function startListeningForServerChanges(): Promise<void> {
+export async function startListeningForServerChanges(): Promise<void> {
 	await getIntegrationsFromKubectlCliWithWatch();
 }
 

--- a/src/test/suite/kubectlwatcher.test.ts
+++ b/src/test/suite/kubectlwatcher.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as sinon from 'sinon';
+import * as extension from '../../extension';
+import * as utils from '../../CamelKJSONUtils';
+
+suite("Kubectl integration watcher", function() {
+
+	let messageSpy = sinon.spy(utils, "shareMessage");
+
+	this.beforeEach(() => {
+		messageSpy.resetHistory();
+	});
+
+	test('Check there is no loop for closing kubectl process', async function() {
+		await sleep(1000);
+		sinon.assert.notCalled(messageSpy);
+	});
+
+	test('Check there is one message logged in case of connection error', async function() {
+		await extension.getIntegrationsFromKubectlCliWithWatch();
+		sinon.assert.calledOnce(messageSpy);
+	});
+
+});
+
+function sleep(ms = 0) {
+	return new Promise(r => setTimeout(r, ms));
+}


### PR DESCRIPTION
available

- start/stop kubectl watch depending if the Apache Camel K view is
visible or not

TODO:
- validate that this watch is used only for Apache Camel K view --> Edit: validated that it is
- write a test --> Edit: test provided

For Future:
- there might a nicer way to handle the running kubectl watch process:
have delay between relaunch in case of timeout, avoid mix of event to
start and direct access to stop

note there is still an infinite loop when teh Apache Camel K view is opened (but at least there is a workaround now and it won't be the default)
