### PR TITLE
FUSETOOLS2-205 - avoid infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.12
 
+- avoid infinite loop when connection to kamel instance is not configured
+
 ## 0.0.11
 
 - Pure Java language support with standalone Camel K Java files (requires vscode-java 0.55.0 and that the file contains the word `camel`)

--- a/src/CamelKNodeProvider.ts
+++ b/src/CamelKNodeProvider.ts
@@ -51,6 +51,12 @@ export class CamelKNodeProvider implements vscode.TreeDataProvider<TreeNode> {
 		return Promise.resolve(this.treeNodes);
 	}
 
+	public getParent(element?: TreeNode) {
+		/* there is only root element currently.
+		   Method is required to be provided for reveal method to work, which is used in tests*/
+		return Promise.resolve(undefined);
+	}
+
 	// add a child to the list of nodes
 	public addChild(oldNodes: TreeNode[] = this.treeNodes, newNode: TreeNode, disableRefresh : boolean = false ): Promise<TreeNode[]> {
 		return new Promise<TreeNode[]>( async (resolve, reject) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ let camelKIntegrationsTreeView : vscode.TreeView<TreeNode>;
 let eventEmitter = new events.EventEmitter();
 const restartKubectlWatchEvent = 'restartKubectlWatch';
 let runningKubectl : ChildProcess | undefined;
+let timestampLastkubectlIntegrationStart = 0;
 
 let stashedContext : vscode.ExtensionContext;
 
@@ -287,6 +288,7 @@ export async function getIntegrationsFromKubectlCliWithWatch() : Promise<void> {
 		kubectlArgs.push('get');
 		kubectlArgs.push(`integrations`);
 		kubectlArgs.push(`-w`);
+		timestampLastkubectlIntegrationStart = Date.now();
 
 		await kubectlExe.invokeArgs(kubectlArgs)
 			.then( async (runKubectl) => {
@@ -299,7 +301,7 @@ export async function getIntegrationsFromKubectlCliWithWatch() : Promise<void> {
 					});
 				}
 				runKubectl.on("close", () => {
-					if (camelKIntegrationsTreeView.visible === true) {
+					if (camelKIntegrationsTreeView.visible === true && Date.now() - timestampLastkubectlIntegrationStart > 1000) {
 						// stopped listening to server - likely timed out
 						eventEmitter.emit(restartKubectlWatchEvent);
 					}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,13 +31,15 @@ import * as config from './config';
 import { downloadJavaDependencies, updateReferenceLibraries } from './JavaDependenciesManager';
 import { ChildProcess } from 'child_process';
 
+export const DELAY_RETRY_KUBECTL_CONNECTION = 1000;
+
 export let mainOutputChannel: vscode.OutputChannel;
 export let myStatusBarItem: vscode.StatusBarItem;
+export let camelKIntegrationsProvider : CamelKNodeProvider;
+export let camelKIntegrationsTreeView : vscode.TreeView<TreeNode | undefined>;
 
-let camelKIntegrationsProvider : CamelKNodeProvider;
 let outputChannelMap : Map<string, vscode.OutputChannel>;
 let showStatusBar : boolean;
-let camelKIntegrationsTreeView : vscode.TreeView<TreeNode>;
 let eventEmitter = new events.EventEmitter();
 const restartKubectlWatchEvent = 'restartKubectlWatch';
 let runningKubectl : ChildProcess | undefined;
@@ -301,7 +303,7 @@ export async function getIntegrationsFromKubectlCliWithWatch() : Promise<void> {
 					});
 				}
 				runKubectl.on("close", () => {
-					if (camelKIntegrationsTreeView.visible === true && Date.now() - timestampLastkubectlIntegrationStart > 1000) {
+					if (camelKIntegrationsTreeView.visible === true && Date.now() - timestampLastkubectlIntegrationStart > DELAY_RETRY_KUBECTL_CONNECTION) {
 						// stopped listening to server - likely timed out
 						eventEmitter.emit(restartKubectlWatchEvent);
 					}


### PR DESCRIPTION
when cannot reach connection and Apache camel k integration Tree view is
opened

no test, seems VS Code TreeView is missing APIs to programmatically open
an empty TreeView... and after few hours for searchign still cannot manage to find a workaround, see also  https://stackoverflow.com/questions/59983711/how-to-programmatically-make-a-treeview-visible?noredirect=1#comment106081291_59983711
