### PR TITLE
FUSETOOLS2-215 - Provide Task to launch Camel K Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.13
 
+- Provide tasks to support multi-arguments launch of Camel K integrations
+
 ## 0.0.12
 
 - avoid infinite loop when connection to kamel instance is not configured

--- a/README.md
+++ b/README.md
@@ -102,6 +102,52 @@ To update the state of your currently deployed integrations, hover over the **Ap
 
 ![Apache Camel K Integrations view - Refresh](images/camelk-integrations-view-refresh-action.jpg)
 
+## Starting a new Camel K Integration with multiple parameters
+
+Using the right-click menu is the easiest way to start a new integration and works well for simple cases. When the Camel K integration requires more configuration, you can set that up using a Task.
+
+To create a new Task, you have a few options.
+
+1. From command palette, call the `Tasks: Configure Task` command. This will open the tasks.json file where you can enter new task info by hand (with some auto-completion support in the editor). If you already have a tasks.json but no Camel K tasks, you can create a new task with type `camel-k` in the tasks.json which is automatically opened.
+2. If you don't have any Tasks configured yet, you can use the `camel-k: Start in dev mode Camel K integration opened in active editor` command, which will template an initial Camel K task for you.
+
+You will end up with something like the following with a new, empty Camel K task specified:
+
+```
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "camel-k",
+            "dev": true,
+            "file": "${file}",
+            "problemMatcher": []
+        }
+    ]
+}
+```
+
+Note: We recommend adding a `label` attribute to more easily find your task in the task list when you try to run it.
+
+Once you've created your Camel K task, you can use auto-complete to explore the various parameters available. The following example launches the integration in `--dev` mode and provides a couple of dependencies:
+
+```
+{
+    "type": "camel-k",
+    "label": "Run RestWithUndertow and Dependencies",
+    "dev": true,
+    "file": "./examples/RestWithUndertow.java",
+    "problemMatcher": [],
+    "dependencies": [ "camel-rest", "camel-undertow" ]
+}
+```
+
+When you're done, save the file and call command from palette `Tasks: Run Task`. You will see the command listed with the label that you provided previously.
+
+After running the camel-k `Task`, a terminal will open where you can see the command used and any execution result.
+
 ## Publishing new Kubernetes ConfigMaps or Secrets
 
 You can use the **Tooling for Apache Camel K** extension to create ConfigMaps and Secrets and publish them to the running Kubernetes system.

--- a/package.json
+++ b/package.json
@@ -166,6 +166,66 @@
 				}
 			]
 		},
+		"taskDefinitions": [
+			{
+				"type": "camel-k",
+				"required": [
+					"file"
+				],
+				"properties": {
+					"compression": {
+						"type": "boolean",
+						"description": "Enable store source as a compressed binary blob"
+					},
+					"configmap": {
+						"type": "string",
+						"description": "Configmap key which needs to be already deployed."
+					},
+					"dependencies": {
+						"type": "array",
+						"description": "Pass additional explicit dependencies with format such as mvn:com.google.guava:guava:26.0-jre or camel-mina2",
+						"uniqueItems": true
+					},
+					"dev": {
+						"type": "boolean",
+						"description": "If you want to iterate quickly on an integration to have fast feedback on the code you’re writing, you can use by running it in dev mode."
+					},
+					"environmentVariables": {
+						"type": "array",
+						"description": "List of environment variables in the integration container. E.g \"MY_VAR=my-value\"",
+						"uniqueItems": true
+					},
+					"file": {
+						"type": "string",
+						"description": "The file defining the integration to deploy."
+					},
+					"profile": {
+						"type": "string",
+						"description": "Trait profile used for deployment"
+					},
+					"properties": {
+						"type": "array",
+						"description": "List of integration properties.",
+						"format": "<akey>=<avalue>",
+						"uniqueItems": true
+					},
+					"resource": {
+						"type": "string",
+						"description": "Additional resource."
+					},
+					"traits": {
+						"type": "array",
+						"description": "Traits configuration, more details here https://camel.apache.org/camel-k/latest/traits/traits.html",
+						"uniqueItems": true
+					},
+					"volumes": {
+						"type": "array",
+						"description": "Mount a volume into the integration container. The format of volume flag value is similar to that of the docker CLI. But instead of specifying a host path to mount from, you reference the name of a PersistentVolumeClaim that you have already configured within the cluster. E.g \"pvcname:/container/path\"",
+						"uniqueItems": true
+					}
+				}
+			}
+		],
 		"views": {
 			"explorer": [
 				{

--- a/src/CamelKTaskDefinition.ts
+++ b/src/CamelKTaskDefinition.ts
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as IntegrationUtils from './IntegrationUtils';
+
+export interface CamelKTaskDefinition extends vscode.TaskDefinition {
+    
+	configmap?: string;
+	compression?: boolean;
+	dependencies?: Array<string>;
+	dev?: boolean;
+	environmentVariables?: Array<string>;
+	file: string;
+	profile?: string;
+	properties?: Array<string>;
+	resource?: string;
+	secret?: string;
+	traits?: Array<string>;
+	volumes?: Array<string>;
+}
+
+export class CamelKTaskProvider implements vscode.TaskProvider {
+
+	private tasks: vscode.Task[] | undefined;
+	static START_CAMELK_TYPE: string = 'camel-k';
+	constructor() { }
+
+	public async provideTasks(): Promise<vscode.Task[]> {
+		return this.getTasks();
+	}
+
+	public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+		const definition: CamelKTaskDefinition = <any>_task.definition;
+		return this.getTask(definition);
+	}
+
+	private getTasks(): vscode.Task[] {
+		if (this.tasks !== undefined) {
+			return this.tasks;
+		}
+		this.tasks = [];
+		let taskDefinition = {
+			"type": CamelKTaskProvider.START_CAMELK_TYPE,
+			"label": "Start in dev mode Camel K integration opened in active editor",
+			"file": "${file}",
+			"dev": true
+		};
+		this.tasks.push(this.getTask(taskDefinition));
+		return this.tasks;
+	}
+
+	public getTask(definition: CamelKTaskDefinition): vscode.Task {
+		let args = IntegrationUtils.computeKamelArgs(definition.file,
+			definition.dev,
+			definition.configmap,
+			definition.secret,
+			definition.resource,
+			definition.dependencies,
+			definition.properties,
+			definition.traits,
+			definition.environmentVariables,
+			definition.volumes,
+			definition.compression,
+			definition.profile);
+		let argsInlined = args.join(' ');
+		let processExecution = new vscode.ShellExecution(`kamel ${argsInlined}`);
+		let displayName :string;
+		if(definition.label) {
+			displayName = definition.label;
+		} else {
+			displayName = `Start Integration for file ${definition.file}`;
+		}
+		return new vscode.Task(definition,
+			vscode.TaskScope.Workspace,
+			displayName,
+			CamelKTaskProvider.START_CAMELK_TYPE,
+			processExecution);
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import * as kubectlutils from './kubectlutils';
 import * as config from './config';
 import { downloadJavaDependencies, updateReferenceLibraries } from './JavaDependenciesManager';
 import { ChildProcess } from 'child_process';
+import { CamelKTaskProvider } from './CamelKTaskDefinition';
 
 export const DELAY_RETRY_KUBECTL_CONNECTION = 1000;
 
@@ -149,6 +150,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		updateReferenceLibraries(vscode.window.activeTextEditor, destination);
 	}
 	
+	vscode.tasks.registerTaskProvider(CamelKTaskProvider.START_CAMELK_TYPE, new CamelKTaskProvider());
 }
 
 

--- a/src/test/suite/CamelKTaskDefinition.test.ts
+++ b/src/test/suite/CamelKTaskDefinition.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { CamelKTaskDefinition, CamelKTaskProvider } from "../../CamelKTaskDefinition";
+import { ShellExecution } from "vscode";
+import { assert } from "chai";
+
+suite("Camel K Task definition", function() {
+
+    test("ensure include configmap", function(done) {
+        let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "configmap": "aDummyConfigMapId",
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--configmap=aDummyConfigMapId');
+        done();
+    });
+
+    test("ensure include compression flag", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "compression": true,
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--compression');
+        done();
+    });
+
+    test("ensure include dependencies", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "dependencies": ["camel.mina2", "mvn:com.google.guava:guava:26.0-jre"],
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--dependency=camel.mina2');
+        assert.include(execution.commandLine, '--dependency=mvn:com.google.guava:guava:26.0-jre');
+        done();
+    });
+
+    test("ensure include dev flag", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "dev": true,
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--dev');
+        done();
+    });
+
+    test("ensure include Environment variables", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "environmentVariables": ["MY_ENV=value", "MY_ENV2=value2"],
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '-e MY_ENV=value');
+        assert.include(execution.commandLine, '-e MY_ENV2=value2');
+        done();
+    });
+
+    test("ensure include target file", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, 'dummyFileValue.xml');
+        done();
+    });
+
+    test("ensure include profile", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "profile": "adummyprofile",
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--profile=adummyprofile');
+        done();
+    });
+
+    test("ensure include properties", function(done) {
+        let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "properties": ["prop1=value1", "prop2=value2"],
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '-p prop1=value1');
+        assert.include(execution.commandLine, '-p prop2=value2');
+        done();
+    });
+
+    test("ensure include resource", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "resource": "adummyresource",
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--resource="adummyresource"');
+        done();
+    });
+
+    test("ensure include secret", function(done) {
+		let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "secret": "adummysecret",
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '--secret=adummysecret');
+        done();
+    });
+    
+    test("ensure include traits", function(done) {
+        let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "traits": ["camel.enabled=true", "camel.runtime-version=3.0.0"],
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '-t camel.enabled=true');
+        assert.include(execution.commandLine, '-t camel.runtime-version=3.0.0');
+        done();
+    });
+    
+    test("ensure include volumes", function(done) {
+        let def: CamelKTaskDefinition = {
+            "file" : "dummyFileValue.xml",
+            "volumes": ["pvcname:/container/path", "pvcname:/container/path2"],
+            "type": CamelKTaskProvider.START_CAMELK_TYPE
+        };
+        let task = new CamelKTaskProvider().getTask(def);
+        let execution = task.execution as ShellExecution;
+        assert.include(execution.commandLine, '-v pvcname:/container/path');
+        assert.include(execution.commandLine, '-v pvcname:/container/path2');
+        done();
+    });
+});


### PR DESCRIPTION
- Task metamodel for most of the kamel attributes possible
- default task to launch indev mode
- using a ShellExecution to allow user to check the command used and the
output of it

improvements possibilities which I think can be handled in another iteration:
- more precise model definition for attributes having a <key>=<value>
list such as properties, environment variables (but need to find how to
specify that in the package.json...)
- improve completion for values of each attributes. Either using a
specific VS Code completion provider, or Language Server for tasks.json
files or defining more in package.json if it is possible (but it won't
be dynamic in that case)
- auto-generate metamodel based on kamel definition (but seems a really
hard task)
- use full kamel path if kamel not available on bin path
- Provide option in "Start Apache Camel K integration" to use a task
when users want a multi-attributes launch
- provide a Camel K task template available as completion in tasks.json

![multiattributesCamelKLaunch](https://user-images.githubusercontent.com/1105127/74246954-98066880-4ce5-11ea-9d75-835c19111e1b.gif)
