### PR TITLE
FUSETOOLS2-235 - provide divider in context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,17 +179,17 @@
 			"view/item/context": [
 				{
 					"command": "camelk.integrations.remove",
-					"group": "group@1",
+					"group": "1_actiongroup",
 					"when": "view == camelk.integrations"
 				},
 				{
 					"command": "camelk.integrations.log",
-					"group": "group@2",
+					"group": "2_loggroup@1",
 					"when": "view == camelk.integrations"
 				},
 				{
 					"command": "camelk.integrations.kitlog",
-					"group": "group@3",
+					"group": "2_loggroup@2",
 					"when": "view == camelk.integrations"
 				}
 			]


### PR DESCRIPTION

![contextualmenuwithdivider](https://user-images.githubusercontent.com/1105127/76742543-87786080-6771-11ea-8f43-c403bfafbe1f.png)

see doc https://code.visualstudio.com/api/references/contribution-points#Sorting-of-groups
