### PR TITLE
FUSETOOLS2-229 - provide initial trait completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.14
 
 - Listing VS Code task to deploy Camel K integration in "Start Apache Camel Integration" command
+- Completion for trait names in tasks.json
 
 ## 0.0.13
 

--- a/src/task/TraitManager.ts
+++ b/src/task/TraitManager.ts
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as kamel from './../kamel';
+import * as vscode from 'vscode';
+
+export class TraitManager {
+
+    static async provideAvailableTraits(): Promise<vscode.CompletionItem[]> {
+        let completions: vscode.CompletionItem[] = [];
+        let kamelExe = kamel.create();
+        let allTraits = await kamelExe.invoke('help trait --all -o json');
+        let traits = JSON.parse(allTraits) as TraitDefinition[];
+        for (let trait of traits) {
+            let completionBasic: vscode.CompletionItem = {
+                label: trait.name,
+                insertText: `"${trait.name}"`
+            };
+            completions.push(completionBasic);
+        }
+        return Promise.resolve(completions);
+    }
+}
+
+interface TraitDefinition {
+    name: string;
+    platform: boolean;
+    profiles: string[];
+    properties: Property[];
+}
+
+interface Property {
+    name: string;
+    type: string;
+    defaultValue?: boolean | number | string;
+}

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -18,6 +18,7 @@
 
 import { expect } from 'chai';
 import { CamelKTaskCompletionItemProvider } from "../../task/CamelKTaskCompletionItemProvider";
+import * as Utils from './Utils';
 
 suite("Camel K Task Completion", function () {
 
@@ -38,6 +39,7 @@ suite("Camel K Task Completion", function () {
     });
 
     test("Completion for traits", async () => {
+        await Utils.ensureExtensionActivated();
         let contentWithEmptyTrait =
 `{
     "version": "2.0.0",

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -17,26 +17,42 @@
 'use strict';
 
 import { expect } from 'chai';
-import * as vscode from 'vscode';
 import { CamelKTaskCompletionItemProvider } from "../../task/CamelKTaskCompletionItemProvider";
 
 suite("Camel K Task Completion", function () {
 
-    let content = `{
+    let simpleContent = `{
         "version": "2.0.0",
         "tasks": [
             
         ]
     }`;
 
-    test("no result outside of tasks", function (done) {
-        expect(new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(content, 2)).to.be.empty;
-        done();
+    test("no result outside of tasks", async () => {
+        expect(await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(simpleContent, 2)).to.be.empty;
     });
 
-    test("One completion in tasks array ", function (done) {
-        let res = new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(content, 49) as vscode.CompletionItem[];
+    test("One completion in tasks array", async () => {
+        let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(simpleContent, 49);
         expect(res).to.have.lengthOf(1);
-        done();
+    });
+
+    test("Completion for traits", async () => {
+        let contentWithEmptyTrait =
+`{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Config with traits",
+            "type": "camel-k",
+            "dev": true,
+            "file": "dummy",
+            "problemMatcher": [],
+            "traits": []
+        }
+    ]
+}`;
+        let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236);
+        expect(res).to.have.lengthOf(26);
     });
 });

--- a/src/test/suite/Utils.ts
+++ b/src/test/suite/Utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+const extensionId = 'redhat.vscode-camelk';
+
+export async function ensureExtensionActivated() {
+    let extension = vscode.extensions.getExtension(extensionId);
+    if (extension !== null && extension !== undefined) {
+        await extension.activate().then( () => {
+            assert.ok("Camel K extension is ready to go");
+        });
+    } else {
+        assert.fail("Camel K extension is undefined and cannot be activated");
+    }
+    return extension;
+}

--- a/src/test/suite/completion.tasks.test.ts
+++ b/src/test/suite/completion.tasks.test.ts
@@ -22,16 +22,26 @@ const os = require('os');
 
 suite('Should do completion in tasks.json', () => {
 	const docURiTasksJson = getDocUri('tasks.json');
-	const expectedCompletion = { label: 'Camel K basic development mode' };
-
+	
 	var testVar = test('Completes for Camel K template', async () => {
-		if(os.homedir().includes('hudson')) {
-			testVar.skip();
-		}
+		assumeNotOnJenkins(testVar);
+		const expectedCompletion = { label: 'Camel K basic development mode' };
 		await testCompletion(docURiTasksJson, new vscode.Position(3, 7), expectedCompletion);
 	});
 
+	var testTraits = test('Completes for traits', async () => {
+		assumeNotOnJenkins(testTraits);
+		const expectedCompletion = { label: 'platform' };
+		await testCompletion(docURiTasksJson, new vscode.Position(9, 23), expectedCompletion);
+	});
+
 });
+
+function assumeNotOnJenkins(testVar: Mocha.Test) {
+	if (os.homedir().includes('hudson')) {
+		testVar.skip();
+	}
+}
 
 async function testCompletion(
 	docUri: vscode.Uri,

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -17,32 +17,22 @@
 'use strict';
 
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as config from '../../config';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as installer from '../../installer';
+import * as Utils from './Utils';
 import * as versionUtils from '../../versionUtils';
 import { failed } from '../../errorable';
-
-const extensionId = 'redhat.vscode-camelk';
 
 suite("ensure install methods are functioning as expected", function() {
 
 	let installKubectlSpy  = sinon.spy(installer, 'installKubectl');
 
 	test("install Camel K and Kubernetes CLIs on activation", async function() {
-		// reset the call count
-		installKubectlSpy.resetHistory();	
+		let extension = await Utils.ensureExtensionActivated();
 
-		let extension = vscode.extensions.getExtension(extensionId);
-		if (extension !== null && extension !== undefined) {
-			await extension.activate().then( () => {
-				assert.ok("Camel K extension is ready to go");
-			});
-		} else {
-			assert.fail("Camel K extension is undefined and cannot be activated");
-		}
+		installKubectlSpy.resetHistory();	
 
 		// now try to activate again to ensure that we don't install a second time
 		if (extension !== null && extension !== undefined) {

--- a/testFixture/tasks.json
+++ b/testFixture/tasks.json
@@ -1,6 +1,13 @@
 {
     "version": "2.0.0",
     "tasks": [
-        
+        {
+            "label": "Config with traits",
+            "type": "camel-k",
+            "dev": true,
+            "file": "${file}",
+            "problemMatcher": [],
+            "traits": []
+        }
     ]
 }


### PR DESCRIPTION
trait completion limited to trait name outside of quotes

![completionTraitNames](https://user-images.githubusercontent.com/1105127/76979430-35ce0280-6938-11ea-8fe2-b4df91a1c7b7.gif)

possible improvements:
- cache Kamel trait list until the kamel cli is updated
- support inside ""
- completion (filtered) when there is a beginning of value typed inside
""
- autocompletes for trait parameter and default values

