### PR TITLE
FUSETOOLS2-139 - Command to create a new Apache Camel K integration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 - Listing VS Code task to deploy Camel K integration in "Start Apache Camel Integration" command
 - Completion for trait names in tasks.json
+- Command to create new Apache Camel K Integration files
 
 ## 0.0.13
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ The **Tooling for Apache Camel K** extension is available in the VS Code Extensi
 
     You can install them by following the same steps except search for Kubernetes or Apache Camel in the list of extensions.
 
+## Creating a new Camel K Integration file
+
+1. From command palette, choose `Create a new Apache Camel K Integration file`
+2. Choose the language to use.
+3. Choose the workspace folder
+4. Provide a name for the new file
+
+The new Apache Camel K Integration file is created at the root of the chosen workspace folder.
+
 ## Starting a new Camel K Integration
 
 After your Apache Camel K/Minikube environment is running and you have installed the **Tooling for Apache Camel K** (vscode-camelk) extension, you can start a new Apache Camel K integration.
@@ -106,7 +115,7 @@ To update the state of your currently deployed integrations, hover over the **Ap
 
 ![Apache Camel K Integrations view - Refresh](images/camelk-integrations-view-refresh-action.jpg)
 
-## Creating a new Camel K Integration with multiple parameters
+## Creating a new Camel K Integration task configuration with multiple parameters
 
 Though the simple "Start Apache Camel K Integration" menu works well for simple cases, you can use a Task for more complex integrations. When the Camel K integration requires more configuration, you can set that up using a Task.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4884,6 +4884,14 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
+		"valid-filename": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/valid-filename/-/valid-filename-3.1.0.tgz",
+			"integrity": "sha512-O99sdfhdGCiWoN4cv6Unq4eJ2EuXwRsOLCeSw+IJyMYgwVK0BPmaUnzhWQw5E8qknLTVrVExCr6xxTBnRBvtsQ==",
+			"requires": {
+				"filename-reserved-regex": "^2.0.0"
+			}
+		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
 			{
 				"command": "camelk.integrations.kitlog",
 				"title": "Follow kit builder log for running Apache Camel K Integration"
+			},
+			{
+				"command": "camelk.integrations.createNewIntegrationFile",
+				"title": "Create a new Apache Camel K Integration file",
+				"enablement": "workspaceFolderCount != 0"
 			}
 		],
 		"menus": {
@@ -331,6 +336,7 @@
 		"shelljs": "^0.8.3",
 		"tar": "^6.0.1",
 		"tmp": "^0.1.0",
+		"valid-filename": "^3.1.0",
 		"vscode-kubernetes-tools-api": "^1.1.0"
 	}
 }

--- a/src/commands/NewIntegrationFileCommand.ts
+++ b/src/commands/NewIntegrationFileCommand.ts
@@ -33,9 +33,10 @@ const LANGUAGES_WITH_FILENAME_EXTENSIONS = new Map([
 const LANGUAGES = Array.from(LANGUAGES_WITH_FILENAME_EXTENSIONS.keys());
 
 export async function create() : Promise<void> {
-	const language = await vscode.window.showQuickPick(LANGUAGES);
+	const language = await vscode.window.showQuickPick(LANGUAGES, {placeHolder:'Please select the language in which the new file will be generated.'});
 	if (language) {
-		const workspaceFolder = await vscode.window.showWorkspaceFolderPick();
+		const workspaceFolder = await vscode.window.showWorkspaceFolderPick(
+			{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
 		if (workspaceFolder) {
 			const filename = await vscode.window.showInputBox({
 				prompt: 'Please provide a name for the new file (without extension)',

--- a/src/commands/NewIntegrationFileCommand.ts
+++ b/src/commands/NewIntegrationFileCommand.ts
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as kamel from '../kamel';
+
+const validFilename = require('valid-filename');
+
+const LANGUAGES_WITH_FILENAME_EXTENSIONS = new Map([
+	['Java', 'java'],
+	['XML', 'xml'],
+	['Yaml', 'yaml'],
+	['Groovy', 'groovy'],
+	['JavaScript', 'js'],
+	['Kotlin', 'kts']]);
+const LANGUAGES = Array.from(LANGUAGES_WITH_FILENAME_EXTENSIONS.keys());
+
+export async function create() : Promise<void> {
+	const language = await vscode.window.showQuickPick(LANGUAGES);
+	if (language) {
+		const workspaceFolder = await vscode.window.showWorkspaceFolderPick();
+		if (workspaceFolder) {
+			const filename = await vscode.window.showInputBox({
+				prompt: 'Please provide a name for the new file (without extension)',
+				validateInput: (name: string) => {
+					return validateFileName(name, language, workspaceFolder);
+				}
+			});
+			if (filename) {
+				const kamelExe = kamel.create();
+				const newFileFullPath: string = computeFullpath(language, workspaceFolder, filename);
+				kamelExe.invoke(`init ${newFileFullPath}`);
+			}
+		}
+	}
+}
+
+function computeFullpath(language: string, workspaceFolder: vscode.WorkspaceFolder, filename: string): string {
+	const extension = getFileExtensionForLanguage(language);
+	return path.join(workspaceFolder.uri.fsPath, `${filename}.${extension}`);
+}
+
+export function validateFileName(name: string, language: string, workspaceFolder: vscode.WorkspaceFolder): string | undefined {
+	if (!name) {
+		return 'Please provide a name for the new file (without extension)';
+	}
+	let newFilePotentialFullPath: string = computeFullpath(language, workspaceFolder, name);
+	if (fs.existsSync(newFilePotentialFullPath)) {
+		return 'There is already a file with the same name. Please choose a different name.';
+	}
+	if (!validFilename(name)) {
+		return 'The filename is invalid.';
+	}
+	const patternJavaNamingConvention = '[A-Z][a-zA-Z_$0-9]*';
+	if ((language === 'Java' || language === 'Groovy') && !name.match(patternJavaNamingConvention)) {
+		return `The filename needs to follow the ${language} naming convention. I.e. ${patternJavaNamingConvention}`;
+	}
+	return undefined;
+}
+
+function getFileExtensionForLanguage(language: string): string {
+	const extension = LANGUAGES_WITH_FILENAME_EXTENSIONS.get(language);
+	if (extension) {
+		return extension;
+	} else {
+		return 'unknown';
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { ChildProcess } from 'child_process';
 import { LogsPanel } from './logsWebview';
 import * as logUtils from './logUtils';
 import {checkKamelNeedsUpdate, version, handleChangeRuntimeConfiguration} from './versionUtils';
+import * as NewIntegrationFileCommand from './commands/NewIntegrationFileCommand';
 
 export const DELAY_RETRY_KUBECTL_CONNECTION = 1000;
 
@@ -156,6 +157,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 				});
 			}
 		});
+
+		vscode.commands.registerCommand('camelk.integrations.createNewIntegrationFile', NewIntegrationFileCommand.create);
 
 	});
 

--- a/src/test/suite/commands/NewIntegrationFileCommand.test.ts
+++ b/src/test/suite/commands/NewIntegrationFileCommand.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { expect } from "chai";
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { fail } from "assert";
+
+const waitUntil = require('async-wait-until');
+
+suite('New Apache Camel K integration file', function() {
+
+	let showQuickpickStub: sinon.SinonStub;
+	let showInputBoxStub: sinon.SinonStub;
+	let showWorkspaceFolderPickStub: sinon.SinonStub;
+	let createdFile: vscode.Uri;
+
+	setup(() => {
+		showQuickpickStub = sinon.stub(vscode.window, 'showQuickPick');
+		showInputBoxStub = sinon.stub(vscode.window, 'showInputBox');
+		showWorkspaceFolderPickStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
+	});
+
+	teardown(() => {
+		showQuickpickStub.restore();
+		showInputBoxStub.restore();
+		showWorkspaceFolderPickStub.restore();
+		if (createdFile && fs.existsSync(createdFile.fsPath)) {
+			fs.unlinkSync(createdFile.fsPath);
+		}
+	});
+
+	test('Can create a new java integration file', async function() {
+		await testIntegrationFileCreation('TestCreation.java', 'Java', 'TestCreation');
+	});
+
+	test('Can create a new xml integration file', async function() {
+		await testIntegrationFileCreation('TestCreation.xml', 'XML', 'TestCreation');
+	});
+
+	test('Can create a new yaml integration file', async function() {
+		await testIntegrationFileCreation('TestCreation.yaml', 'Yaml', 'TestCreation');
+	});
+
+	test('Can create a new Groovy integration file', async function() {
+		await testIntegrationFileCreation('TestCreation.groovy', 'Groovy', 'TestCreation');
+	});
+
+	test('Can create a new Kotlin integration file', async function() {
+		await testIntegrationFileCreation('TestCreation.kts', 'Kotlin', 'TestCreation');
+	});
+
+	test('Can create a new JavaScript integration file', async function() {
+		await testIntegrationFileCreation('TestCreation.js', 'JavaScript', 'TestCreation');
+	});
+
+	async function testIntegrationFileCreation(expectedFileNameWithExtension: string, languageToPick: string, providedFilename: string) {
+		expect(await vscode.workspace.findFiles(expectedFileNameWithExtension)).to.be.an('array').that.is.empty;
+		showQuickpickStub.onFirstCall().returns(languageToPick);
+		const workspaceFolder = (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0];
+		showWorkspaceFolderPickStub.returns(workspaceFolder);
+		showInputBoxStub.onFirstCall().returns(providedFilename);
+
+		await vscode.commands.executeCommand('camelk.integrations.createNewIntegrationFile');
+
+		await checkFileCreated(expectedFileNameWithExtension);
+
+		checkContainsCamelKMode(createdFile);
+	}
+
+	function checkContainsCamelKMode(file: vscode.Uri) {
+		expect(fs.readFileSync(file.fsPath, 'utf-8')).to.include("camel-k");
+	}
+
+	async function checkFileCreated(expectedFileNameWithExtension: string) {
+		let files: vscode.Uri[] = [];
+		await waitUntil(() => {
+			vscode.workspace.findFiles(expectedFileNameWithExtension).then(res => {
+				files = res;
+			});
+			if (files.length === 1) {
+				createdFile = files[0];
+				return true;
+			}
+			return false;
+		}).catch(() => {
+			fail(
+				`File with expected name ${expectedFileNameWithExtension} not found in the workspace when calling command to create a new Camel K file.\n`+
+				`Until https://github.com/apache/camel-k/issues/1368 is fixed, it will require to have a valid local Kubernetes setup.`);
+		});
+	}
+});

--- a/src/test/suite/commands/NewIntegrationFileCommandValidation.test.ts
+++ b/src/test/suite/commands/NewIntegrationFileCommandValidation.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+import * as NewIntegrationFileCommand from '../../../commands/NewIntegrationFileCommand';
+
+
+suite('New Apache Camel K integration file - file name validation', function() {
+	const workspaceFolder = (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0];
+
+	test('Message on empty name', function() {
+		expect(NewIntegrationFileCommand.validateFileName('', 'Java', workspaceFolder)).to.not.be.undefined;
+	});
+
+	test('Message on invalid name', function() {
+		expect(NewIntegrationFileCommand.validateFileName('with a slash/', 'Java', workspaceFolder)).to.not.be.undefined;
+	});
+
+	test('Message if file already exists', function() {
+		expect(NewIntegrationFileCommand.validateFileName('MyRouteBuilder', 'Java', workspaceFolder)).to.not.be.undefined;
+	});
+
+	test('No Message on valid name for java', function() {
+		expect(NewIntegrationFileCommand.validateFileName('Valid', 'Java', workspaceFolder)).to.be.undefined;
+	});
+
+	test('No Message on valid name for xml', function() {
+		expect(NewIntegrationFileCommand.validateFileName('valid', 'xml', workspaceFolder)).to.be.undefined;
+	});
+
+	test('Message on invalid Java Convention', function() {
+		expect(NewIntegrationFileCommand.validateFileName('invalid', 'Java', workspaceFolder)).to.not.be.undefined;
+	});
+});


### PR DESCRIPTION
- requires a root folder
- can be created only at the root
- only create the file, doesn't open it due to issues with kamel.exec
not returning. So will be improved in another iteration, see https://issues.redhat.com/browse/FUSETOOLS2-303

![NewApacheCamelKFileCreation](https://user-images.githubusercontent.com/1105127/77341736-76aa8a80-6d2f-11ea-8a45-15bef8f11560.gif)

please note that a kubeconfigf needs to be available currently, see [here](https://github.com/apache/camel-k/issues/1368)
Potential error on creation are not reported but it is linked to the problem of kamel.exec