### PR TITLE
FUSETOOLS2-305 use cache for latest Camel version available

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -24,4 +24,4 @@
 
 # Note about test execution and GitHub API access
 
-Access to GitHub API has rate limit. This rate limit is lower for unauthenticated request. On CI, this rate limit was often hit (either Travis or Jenkins). To avoid that, a GitHub token needs to be provided through VSCODE_CAMELK_GITHUB_TOKEN environment variable. This token doesn't require any specific rights.
+Access to GitHub API has a rate limit. This rate limit is lower for unauthenticated requests. On CI, this rate limit was often hit (either Travis or Jenkins). To avoid that, a GitHub token needs to be provided through VSCODE_CAMELK_GITHUB_TOKEN environment variable. This token doesn't require any specific rights.

--- a/Contributing.md
+++ b/Contributing.md
@@ -21,3 +21,7 @@
   * Run 'npm install' so that the package-lock.json is updated
   * Push changes in a PR
   * Follow PR until it is approved/merged
+
+# Note about test execution and GitHub API access
+
+Access to GitHub API has rate limit. This rate limit is lower for unauthenticated request. On CI, this rate limit was often hit (either Travis or Jenkins). To avoid that, a GitHub token needs to be provided through VSCODE_CAMELK_GITHUB_TOKEN environment variable. This token doesn't require any specific rights.

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -128,15 +128,18 @@ function updateStatusBarItem(sbItem : vscode.StatusBarItem, text: string, toolti
 }
 
 export async function installKamel(context: vscode.ExtensionContext): Promise<Errorable<null>> {
-	const latestversion = await versionUtils.getLatestCamelKVersion();
-	if (failed(latestversion)) {
-		return { succeeded: false, error: latestversion.error };
-	}
-
-	let versionToUse = latestversion.result.trim();
+	let versionToUse: string;
 	let runtimeVersionSetting = vscode.workspace.getConfiguration().get(config.RUNTIME_VERSION_KEY) as string;
 	if (runtimeVersionSetting && runtimeVersionSetting.toLowerCase() !== versionUtils.version.toLowerCase()) {
 		versionToUse = runtimeVersionSetting;
+	} else {
+		const latestversion = await versionUtils.getLatestCamelKVersion();
+		if (failed(latestversion)) {
+			extension.shareMessageInMainOutputChannel(`Cannot retrieve latest available Camel version and none specified in settings. Will fallback to use the default ${versionUtils.version}`);
+			versionToUse = versionUtils.version;
+		} else {
+			versionToUse = latestversion.result.trim();
+		}
 	}
 
 	await versionUtils.checkKamelNeedsUpdate(versionToUse).then((needsUpdate) => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -129,13 +129,13 @@ function updateStatusBarItem(sbItem : vscode.StatusBarItem, text: string, toolti
 
 export async function installKamel(context: vscode.ExtensionContext): Promise<Errorable<null>> {
 	let versionToUse: string;
-	let runtimeVersionSetting = vscode.workspace.getConfiguration().get(config.RUNTIME_VERSION_KEY) as string;
+	const runtimeVersionSetting = vscode.workspace.getConfiguration().get(config.RUNTIME_VERSION_KEY) as string;
 	if (runtimeVersionSetting && runtimeVersionSetting.toLowerCase() !== versionUtils.version.toLowerCase()) {
 		versionToUse = runtimeVersionSetting;
 	} else {
 		const latestversion = await versionUtils.getLatestCamelKVersion();
 		if (failed(latestversion)) {
-			extension.shareMessageInMainOutputChannel(`Cannot retrieve latest available Camel version and none specified in settings. Will fallback to use the default ${versionUtils.version}`);
+			extension.shareMessageInMainOutputChannel(`Cannot retrieve latest available Camel version and none has been specified in settings. Will fall back to use the default ${versionUtils.version}`);
 			versionToUse = versionUtils.version;
 		} else {
 			versionToUse = latestversion.result.trim();

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -50,7 +50,11 @@ suite("ensure install methods are functioning as expected", function() {
 		installKubectlSpy.resetHistory();	
 	});
 
-	test("ensure cli version checking works correctly", async function() {
+	var testVar = test("ensure cli version checking works correctly", async function() {
+		if(process.env.VSCODE_CAMELK_GITHUB_TOKEN === undefined) {
+			testVar.skip();
+		}
+
 		await versionUtils.checkKamelNeedsUpdate('bogusversion').then( () => {
 			assert.fail('cli version checking, negative case worked');
 		}).catch( (error) => {

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -51,7 +51,7 @@ suite("ensure install methods are functioning as expected", function() {
 	});
 
 	var testVar = test("ensure cli version checking works correctly", async function() {
-		if(process.env.VSCODE_CAMELK_GITHUB_TOKEN === undefined) {
+		if(!process.env.VSCODE_CAMELK_GITHUB_TOKEN) {
 			testVar.skip();
 		}
 

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -110,14 +110,14 @@ export async function getLatestCamelKVersion(): Promise<Errorable<string>> {
 	} else {
 		const latestURL = 'https://api.github.com/repos/apache/camel-k/releases/latest';
 		const headers = [['If-Modified-Since', LAST_MODIFIED_DATE_OF_DEFAULT_VERSION]];
-		let githubToken = process.env.VSCODE_CAMELK_GITHUB_TOKEN;
+		const githubToken = process.env.VSCODE_CAMELK_GITHUB_TOKEN;
 		if(githubToken) {
 			headers.push(['Authorization', `token ${githubToken}`]);
 		}
 		const res = await fetch(latestURL, { headers: headers });
 		if (res.status === 200) {
-			let latestJSON = await res.json();
-			let tagName = latestJSON.tag_name;
+			const latestJSON = await res.json();
+			const tagName = latestJSON.tag_name;
 			if (tagName) {
 				latestVersionFromOnline = tagName;
 				return { succeeded: true, result: tagName };
@@ -136,7 +136,7 @@ export async function getLatestCamelKVersion(): Promise<Errorable<string>> {
 
 function checkKamelCLIVersion(): Promise<string> {
 	return new Promise<string>(async (resolve, reject) => {
-		let kamelLocal = kamelCli.create();
+		const kamelLocal = kamelCli.create();
 		await kamelLocal.invoke('version')
 			.then((rtnValue) => {
 				const strArray = rtnValue.split(' ');

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -25,7 +25,7 @@ import fetch from 'cross-fetch';
 
 export const version: string = '1.0.0-RC2'; //need to retrieve this if possible, but have a default
 /*
-* Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searchign for "last-modified" attribute
+* Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searching for "last-modified" attribute
 * To be updated when updating the default "version" attribute
 */
 const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Fri, 28 Feb 2020 07:24:17 GMT';


### PR DESCRIPTION
- the cache needs a restart of VS Code to be updated
- given that the version is modified no more than once a month, I don't
think that it is a problem
- the idea is also to avoid 403 rate limit exceeded when playing tests
on CIs