### PR TITLE
FUSETOOLS2-354 - increase timeout for completion test

### DIFF
--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -56,5 +56,5 @@ suite("Camel K Task Completion", function () {
 }`;
         let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236);
         expect(res).to.have.lengthOf(26);
-    });
+    }).timeout(120000);
 });


### PR DESCRIPTION
currently test failing on Jenkins CI with timeout, the method called
waiting for activation had an higher timeout than the test itself.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>