### PR TITLE
FUSETOOLS2-356 - provide trait properties when choosing trait

### DIFF
--- a/src/task/CamelKTaskCompletionItemProvider.ts
+++ b/src/task/CamelKTaskCompletionItemProvider.ts
@@ -22,65 +22,66 @@ import { TraitManager } from './TraitManager';
 
 export class CamelKTaskCompletionItemProvider implements vscode.CompletionItemProvider {
 
-    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
-        return this.provideCompletionItemsForText(document.getText(), document.offsetAt(position));
-    }
+	provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
+		return this.provideCompletionItemsForText(document.getText(), document.offsetAt(position));
+	}
 
-    public async provideCompletionItemsForText(text: string, offset: number): Promise<vscode.CompletionItem[]> {
-        let node = jsonparser.findNodeAtOffset(jsonparser.parseTree(text), offset, false);
-        let completions: vscode.CompletionItem[] = [];
-        if (node !== undefined) {
-            if (this.isInTasksArray(node)) {
-                let completionBasic: vscode.CompletionItem = {
-                    label: 'Camel K basic development mode',
-                    insertText:
-`{
+	public async provideCompletionItemsForText(text: string, offset: number): Promise<vscode.CompletionItem[]> {
+		const globalNode = jsonparser.parseTree(text);
+		const node = jsonparser.findNodeAtOffset(globalNode, offset, false);
+		let completions: vscode.CompletionItem[] = [];
+		if (node) {
+			if (this.isInTasksArray(node)) {
+				const completionBasic: vscode.CompletionItem = {
+					label: 'Camel K basic development mode',
+					insertText:
+						`{
     "label": "Start in dev mode Camel K integration opened in active editor",
     "type": "camel-k",
     "dev": true,
     "file": "\${file}",
     "problemMatcher": []
 }`
-                };
-                completions.push(completionBasic);
-            } else if(this.isInTraitsArray(node)) {
-                let traitCompletions: vscode.CompletionItem[] = await TraitManager.provideAvailableTraits();
-                completions = completions.concat(traitCompletions);
-            }
-        }
-        return Promise.resolve(completions);
-    }
+				};
+				completions.push(completionBasic);
+			} else if (this.isInTraitsArray(node)) {
+				const traitCompletions: vscode.CompletionItem[] = await TraitManager.provideAvailableTraits();
+				completions = completions.concat(traitCompletions);
+			}
+		}
+		return Promise.resolve(completions);
+	}
 
-    private isInTraitsArray(node: jsonparser.Node) {
-        return this.isInArray(node)
-            && this.isSiblingTraitTasks(node);
-    }
+	private isInTraitsArray(node: jsonparser.Node) {
+		return this.isInArray(node)
+			&& this.isSiblingTraitTasks(node);
+	}
 
-    private isParentHasStringPropertyOfType(node: jsonparser.Node, type: string) {
-        let parent = node.parent;
-        if (parent !== undefined && parent.type === "property") {
-            let nodeTasks = parent.children?.find(child => {
-                return child.type === "string" && child.value === type;
-            });
-            return nodeTasks !== undefined;
-        }
-        return false;
-    }
+	private isParentHasStringPropertyOfType(node: jsonparser.Node, type: string) {
+		const parent = node.parent;
+		if (parent !== undefined && parent.type === "property") {
+			const nodeTasks = parent.children?.find(child => {
+				return child.type === "string" && child.value === type;
+			});
+			return nodeTasks !== undefined;
+		}
+		return false;
+	}
 
-    private isSiblingTraitTasks(node: jsonparser.Node) {
-        return this.isParentHasStringPropertyOfType(node, 'traits');
-    }
+	private isSiblingTraitTasks(node: jsonparser.Node) {
+		return this.isParentHasStringPropertyOfType(node, 'traits');
+	}
 
-    private isInTasksArray(node: jsonparser.Node) {
-        return this.isInArray(node)
-            && this.isParentTasks(node);
-    }
+	private isInTasksArray(node: jsonparser.Node) {
+		return this.isInArray(node)
+			&& this.isParentTasks(node);
+	}
 
-    private isInArray(node: jsonparser.Node) {
-        return node?.type === "array";
-    }
+	private isInArray(node: jsonparser.Node) {
+		return node?.type === "array";
+	}
 
-    private isParentTasks(node: jsonparser.Node) {
-        return this.isParentHasStringPropertyOfType(node, 'tasks');
-    }
+	private isParentTasks(node: jsonparser.Node) {
+		return this.isParentHasStringPropertyOfType(node, 'tasks');
+	}
 }

--- a/src/task/TraitDefinition.ts
+++ b/src/task/TraitDefinition.ts
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { TraitProperty } from './TraitProperty';
+
+export interface TraitDefinition {
+	name: string;
+	platform: boolean;
+	profiles: string[];
+	properties: TraitProperty[];
+}

--- a/src/task/TraitManager.ts
+++ b/src/task/TraitManager.ts
@@ -18,6 +18,7 @@
 
 import * as kamel from '../kamel';
 import * as vscode from 'vscode';
+import { TraitDefinition } from './TraitDefinition';
 
 export class TraitManager {
 
@@ -46,17 +47,4 @@ export class TraitManager {
 		const trait = await kamelExe.invoke(`help trait --all -o json`);
 		return JSON.parse(trait) as TraitDefinition[];
 	}
-}
-
-interface TraitDefinition {
-	name: string;
-	platform: boolean;
-	profiles: string[];
-	properties: Property[];
-}
-
-interface Property {
-	name: string;
-	type: string;
-	defaultValue?: boolean | number | string;
 }

--- a/src/task/TraitProperty.ts
+++ b/src/task/TraitProperty.ts
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+export interface TraitProperty {
+	name: string;
+	type: string;
+	defaultValue?: boolean | number | string;
+}

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -19,6 +19,7 @@
 import { expect } from 'chai';
 import { CamelKTaskCompletionItemProvider } from "../../task/CamelKTaskCompletionItemProvider";
 import * as Utils from './Utils';
+import * as vscode from 'vscode';
 
 suite("Camel K Task Completion", function () {
 
@@ -54,7 +55,11 @@ suite("Camel K Task Completion", function () {
         }
     ]
 }`;
-        let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236);
-        expect(res).to.have.lengthOf(26);
+		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236);
+		expect(res).to.have.lengthOf(26);
+		const affinityCompletionItem = res.find(item => item.label === 'affinity');
+		const affinitySnippet = affinityCompletionItem?.insertText as vscode.SnippetString;
+		expect(affinitySnippet.value).equals('"affinity.${1|enabled,pod-affinity,pod-anti-affinity,node-affinity-labels,pod-affinity-labels,pod-anti-affinity-labels|}="');
     }).timeout(120000);
+
 });


### PR DESCRIPTION
recommending to compare using ignore whitespace, I updated the spaces issue. (if it is a problem i can create a different PR)

![completionSnippetTrait](https://user-images.githubusercontent.com/1105127/79470633-f0b5f280-8001-11ea-94e9-b4b2d026dd4e.gif)


not added items to changelog as I think it can stay in the generic "completion for trait names in tasks.json" already available