### PR TITLE
FUSETOOLS2-290 - provide completion for trait properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.14
 
 - Listing VS Code task to deploy Camel K integration in "Start Apache Camel Integration" command
-- Completion for trait names in tasks.json
+- Completion for trait names and trait properties in tasks.json
 - Command to create new Apache Camel K Integration files
 
 ## 0.0.13

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -31,11 +31,11 @@ suite("Camel K Task Completion", function () {
     }`;
 
     test("no result outside of tasks", async () => {
-        expect(await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(simpleContent, 2)).to.be.empty;
+        expect(await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(simpleContent, 2, new vscode.Position(0,2))).to.be.empty;
     });
 
     test("One completion in tasks array", async () => {
-        let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(simpleContent, 49);
+        let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(simpleContent, 49, new vscode.Position(2,19));
         expect(res).to.have.lengthOf(1);
     });
 
@@ -55,11 +55,32 @@ suite("Camel K Task Completion", function () {
         }
     ]
 }`;
-		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236);
+		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236, new vscode.Position(9,24));
 		expect(res).to.have.lengthOf(26);
 		const affinityCompletionItem = res.find(item => item.label === 'affinity');
 		const affinitySnippet = affinityCompletionItem?.insertText as vscode.SnippetString;
 		expect(affinitySnippet.value).equals('"affinity.${1|enabled,pod-affinity,pod-anti-affinity,node-affinity-labels,pod-affinity-labels,pod-anti-affinity-labels|}="');
     }).timeout(120000);
 
+    test("Completion for trait properties", async () => {
+        await Utils.ensureExtensionActivated();
+        let contentWithPropertyTrait =
+`{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Config with traits",
+            "type": "camel-k",
+            "dev": true,
+            "file": "dummy",
+            "problemMatcher": [],
+            "traits": ["affinity."]
+        }
+    ]
+}`;
+		const position = new vscode.Position(9,34);
+        let res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithPropertyTrait, 246, position);
+		expect(res).to.have.lengthOf(6);
+		expect(res[0].range).deep.equal(new vscode.Range(position, position));
+    }).timeout(120000);
 });

--- a/src/test/suite/completion.tasks.test.ts
+++ b/src/test/suite/completion.tasks.test.ts
@@ -35,6 +35,12 @@ suite('Should do completion in tasks.json', () => {
 		await testCompletion(docURiTasksJson, new vscode.Position(9, 23), expectedCompletion);
 	});
 
+	var testTraitProperties = test('Completes for trait properties', async () => {
+		assumeNotOnJenkins(testTraitProperties);
+		const expectedCompletion = { label: 'enabled' };
+		await testCompletion(docURiTasksJson, new vscode.Position(17, 33), expectedCompletion);
+	});
+
 });
 
 function assumeNotOnJenkins(testVar: Mocha.Test) {

--- a/testFixture/tasks.json
+++ b/testFixture/tasks.json
@@ -8,6 +8,14 @@
             "file": "${file}",
             "problemMatcher": [],
             "traits": []
+		},
+		{
+            "label": "Config for trait properties",
+            "type": "camel-k",
+            "dev": true,
+            "file": "${file}",
+            "problemMatcher": [],
+            "traits": ["affinity."]
         }
     ]
 }


### PR DESCRIPTION
- range needs to be dummy specified otherwise VS Code framework is
filtering completion out for some reasons (see
https://github.com/microsoft/vscode/issues/95449#issuecomment-621896285
)
- prefix is required to have completions appearing before the long list
of defaults variables in tasks.json context

![completiontraitProperty](https://user-images.githubusercontent.com/1105127/80948923-558b8e00-8df3-11ea-9c76-6bc9848be56d.gif)

for next iterations:
- provide default value of property https://issues.redhat.com/browse/FUSETOOLS2-419
- provide snippet with a list of potential value for the property in case of enums https://issues.redhat.com/browse/FUSETOOLS2-420

a non-regression tes for the whole use case, needs ot beprovided at UI level due to mentioned VS Code behavior https://github.com/microsoft/vscode/issues/95449#issuecomment-621896285 , created https://issues.redhat.com/browse/FUSETOOLS2-418