### PR TITLE
FUSETOOLS2-311 - fix issue when calling "escape" on task list of "Start

### DIFF
--- a/src/IntegrationUtils.ts
+++ b/src/IntegrationUtils.ts
@@ -142,8 +142,13 @@ const choiceList = [
 					// do nothing with config-map or secret
 					break;
 				case vscodeTasksIntegration:
-					await handleDefinedTask(context);
-					resolve();
+					await handleDefinedTask(context).then(() => {
+						resolve();
+					}).catch(onrejected => {
+						reject(onrejected);
+						errorEncountered = true;
+					});
+					return;
 			}
 
 			if (!errorEncountered) {
@@ -176,6 +181,8 @@ async function handleDefinedTask(context: vscode.Uri) {
 			if(camelKTaskToLaunch) {
 				await vscode.tasks.executeTask(camelKTaskToLaunch);
 			}
+		} else {
+			throw new Error('No Camel K Task chosen');
 		}
 	} else {
 		await vscode.window.showInformationMessage('No Camel K Task applicable has been found. You can create one using "Tasks: Open User Tasks" or by creating a tasks.json file in .vscode folder.');

--- a/src/test/suite/IntegrationUtils.test.ts
+++ b/src/test/suite/IntegrationUtils.test.ts
@@ -19,48 +19,70 @@
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as IntegrationUtils from './../../IntegrationUtils';
+import { assert } from 'chai';
 import { getDocUri } from './completion.util';
 
-suite("IntegrationUtil tests", function() {
+suite("IntegrationUtil tests", function () {
 
-    let sandbox: sinon.SinonSandbox;
-    let showQuickPickStub: sinon.SinonStub;
-    let executeTaskStub: sinon.SinonStub;
-    
-    setup(() => {
+	let sandbox: sinon.SinonSandbox;
+	let showQuickPickStub: sinon.SinonStub;
+	let executeTaskStub: sinon.SinonStub;
+	let newIntegrationStub: sinon.SinonStub;
+
+	setup(() => {
 		sandbox = sinon.createSandbox();
-        showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-        executeTaskStub = sandbox.stub(vscode.tasks, 'executeTask');
-	});	
+		showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
+		executeTaskStub = sandbox.stub(vscode.tasks, 'executeTask');
+		newIntegrationStub = sandbox.stub(IntegrationUtils, 'createNewIntegration');
+	});
 
 	teardown(() => {
-        showQuickPickStub.restore();
-        executeTaskStub.restore();
+		showQuickPickStub.restore();
+		executeTaskStub.restore();
+		newIntegrationStub.restore();
 		sandbox.reset();
 	});
 
-    test("ensure listing Camel K task when accessing 'Start Apache Camel Integration'", async function() {
-        showQuickPickStub.onFirstCall().returns(IntegrationUtils.vscodeTasksIntegration);
-        showQuickPickStub.onSecondCall().returns('Test Camel K task');
-        
-        await IntegrationUtils.startIntegration(getDocUri('MyRouteBuilder.java'));
-        
-        sinon.assert.calledWith(showQuickPickStub,
-            ['Start in dev mode Camel K integration opened in active editor', 'Test Camel K task'],
-            {placeHolder: 'Choose a predefined task'});
-        sinon.assert.calledOnce(executeTaskStub);
-    });
+	test("ensure listing Camel K task when accessing 'Start Apache Camel Integration'", async function () {
+		showQuickPickStub.onFirstCall().returns(IntegrationUtils.vscodeTasksIntegration);
+		showQuickPickStub.onSecondCall().returns('Test Camel K task');
 
-    test("ensure filtering out Camel K task with unrelated target file when accessing 'Start Apache Camel Integration'", async function() {
-        showQuickPickStub.onFirstCall().returns(IntegrationUtils.vscodeTasksIntegration);
-        showQuickPickStub.onSecondCall().returns(undefined);
-        
-        await IntegrationUtils.startIntegration(getDocUri('ADifferentRouteBuilder.java'));
+		await IntegrationUtils.startIntegration(getDocUri('MyRouteBuilder.java'));
 
-        sinon.assert.calledWith(showQuickPickStub,
-            ['Start in dev mode Camel K integration opened in active editor'],
-            {placeHolder: 'Choose a predefined task'});
-        sinon.assert.notCalled(executeTaskStub);
-    });
-    
+		sinon.assert.calledWith(showQuickPickStub,
+			['Start in dev mode Camel K integration opened in active editor', 'Test Camel K task'],
+			{ placeHolder: 'Choose a predefined task' });
+		sinon.assert.calledOnce(executeTaskStub);
+	});
+
+	test("ensure filtering out Camel K task with unrelated target file when accessing 'Start Apache Camel Integration'", async function () {
+		showQuickPickStub.onFirstCall().returns(IntegrationUtils.vscodeTasksIntegration);
+		showQuickPickStub.onSecondCall().returns(undefined);
+
+		try {
+			await IntegrationUtils.startIntegration(getDocUri('ADifferentRouteBuilder.java'));
+		} catch (error) {
+			assert.exists(error);
+		}
+
+		sinon.assert.calledWith(showQuickPickStub,
+			['Start in dev mode Camel K integration opened in active editor'],
+			{ placeHolder: 'Choose a predefined task' });
+		sinon.assert.notCalled(executeTaskStub);
+	});
+
+	test("ensure no action called on cancel of defined task from 'Start Apache Camel Integration'", async function () {
+		showQuickPickStub.onFirstCall().returns(IntegrationUtils.vscodeTasksIntegration);
+		showQuickPickStub.onSecondCall().returns(undefined);
+
+		try {
+			await IntegrationUtils.startIntegration(getDocUri('MyRouteBuilder.java'));
+			sinon.assert.fail('The command should be in error.');
+		} catch (error) {
+			assert.exists(error);
+			sinon.assert.notCalled(executeTaskStub);
+			sinon.assert.notCalled(newIntegrationStub);
+		}
+	});
+
 });


### PR DESCRIPTION
Apache Camel Integration" list

it is currently logging an error in the VS Code Camel K output. Not sure
that it is needed but it is coherent with the other cases of the "Start
Apache Camel Integration" command when an "escape" is called in one of
the inputbox

Signed-off-by: Aurélien Pupier <apupier@redhat.com>