### PR TITLE
FUSETOOLS2-303 - open created file in editor

### DIFF
--- a/src/commands/NewIntegrationFileCommand.ts
+++ b/src/commands/NewIntegrationFileCommand.ts
@@ -47,7 +47,9 @@ export async function create() : Promise<void> {
 			if (filename) {
 				const kamelExe = kamel.create();
 				const newFileFullPath: string = computeFullpath(language, workspaceFolder, filename);
-				kamelExe.invoke(`init "${newFileFullPath}"`);
+				await kamelExe.invoke(`init "${newFileFullPath}"`);
+				const textDocument = await vscode.workspace.openTextDocument(newFileFullPath);
+				await vscode.window.showTextDocument(textDocument);
 			}
 		}
 	}

--- a/src/kamel.ts
+++ b/src/kamel.ts
@@ -87,15 +87,21 @@ async function kamelInternal(command: string, devMode: boolean, namespace : stri
 					}
 					resolve(data);
 				});
-				return;
 			}        
 			if (sr.stderr) {
 				sr.stderr.on('data', function (data) {
 					utils.shareMessage(extension.mainOutputChannel, `${data}`);
 					reject(new Error(data));
 				});
-				return;
-			}				
+			}
+			sr.on('close', function (exitCode) {
+				const exitCodeAsString = exitCode.toString();
+				if(exitCode === 0){
+					resolve(exitCodeAsString);
+				} else {
+					reject(new Error(exitCodeAsString));
+				}
+			});
 		}
 	});
 }

--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -17,8 +17,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { areJavaDependenciesDownloaded } from '../../JavaDependenciesManager';
-import { getDocUri, checkExpectedCompletion } from './completion.util';
+import { areJavaDependenciesDownloaded } from '../../../JavaDependenciesManager';
+import { getDocUri, checkExpectedCompletion } from '../completion.util';
 import { fail } from 'assert';
 
 const os = require('os');

--- a/src/test/suite/_completion/completion.tasks.test.ts
+++ b/src/test/suite/_completion/completion.tasks.test.ts
@@ -17,7 +17,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { getDocUri, checkExpectedCompletion } from './completion.util';
+import { getDocUri, checkExpectedCompletion } from '../completion.util';
 const os = require('os');
 
 suite('Should do completion in tasks.json', () => {

--- a/src/test/suite/commands/NewIntegrationFileCommand.test.ts
+++ b/src/test/suite/commands/NewIntegrationFileCommand.test.ts
@@ -25,7 +25,7 @@ import { fail } from "assert";
 const os = require('os');
 const waitUntil = require('async-wait-until');
 
-suite('New Apache Camel K integration file', function() {
+suite('Test command to create an Apache Camel K integration file', function() {
 
 	let showQuickpickStub: sinon.SinonStub;
 	let showInputBoxStub: sinon.SinonStub;

--- a/src/test/suite/commands/NewIntegrationFileCommand.test.ts
+++ b/src/test/suite/commands/NewIntegrationFileCommand.test.ts
@@ -89,6 +89,10 @@ suite('New Apache Camel K integration file', function() {
 
 		await checkFileCreated(expectedFileNameWithExtension);
 
+		await waitUntil(() => {
+			return vscode.window.activeTextEditor?.document.fileName.endsWith(expectedFileNameWithExtension);
+		}, 5000, `Text editor has not opened for ${providedFilename}`);
+
 		checkContainsCamelKMode(createdFile);
 	}
 


### PR DESCRIPTION
note: updated the kamel invoke method to resolve promise on 'close'
event. Otherwise the Promise was never resolved even if the command
ended.

![createnewCamelKFileWithEditorOpening](https://user-images.githubusercontent.com/1105127/81071948-b5faf800-8ee5-11ea-827e-0162fa965099.gif)

--> not modified changelog as I don't think it is worthy to add a specific line for it given that the new command to create Integration file is already provided