### PR TITLE
FUSETOOLS2-4 - improve message error when Camel K installation not

### DIFF
--- a/src/kamel.ts
+++ b/src/kamel.ts
@@ -130,7 +130,19 @@ async function kamelInternalArgs(args: string[], devMode: boolean, namespace: st
 				}        
 				if (sr.stderr) {
 					sr.stderr.on('data', function (data) {
-						utils.shareMessage(extension.mainOutputChannel, `${data}`);
+						const errorMessage = `${data}`;
+						utils.shareMessage(extension.mainOutputChannel, errorMessage);
+						if (errorMessage.includes('no matches for kind "Integration"')
+								&& errorMessage.includes('camel.apache.org')) {
+							utils.shareMessage(extension.mainOutputChannel,
+								'It seems that the targeted container host doesn\'t have Camel K installed.\n'
+								+'Please check documentation at https://camel.apache.org/camel-k/latest/installation/installation.html to install it.');
+						}
+						if (errorMessage.includes('cannot get command client:')) {
+							utils.shareMessage(extension.mainOutputChannel,
+								'It seems that no container host can be reached.\n'
+								+'Please check documentation at https://camel.apache.org/camel-k/latest/installation/installation.html to install one with Camel K.');
+						}
 					});
 				}
 				resolve(sr);


### PR DESCRIPTION
correct

would be better if underlying kamel/kubectl provides more precise
message but I think they are targeting users with different set of
skills and it will require a lot more work to include it upstream. So as
a first iteration,
here is this not very nice but  improving slightly UX for users.

testing it would require quite a lot of refactor and mock. Not sure if
it is worthy.

If the approach seems fine, we can discuss to take time to write the test or not. i wanted to share this kind of modification before investing any time on the testing because even if improving UX slightly, it is really ugly. But I don't have a better idea on short term.