### PR TITLE
FUSETOOLS2-482 - use correct style to emphasize in Didact tutorial

### DIFF
--- a/didact/camelk/first-integration.md
+++ b/didact/camelk/first-integration.md
@@ -100,7 +100,7 @@ Since this is likely the first time you've started a new integration in Camel K,
 
 While our integration is running in `Dev Mode`, we can modify it and see those changes reflected in the deployed integration. Let's try that now.
 
-Change the message sent to the `.simple()` command of the Camel route in quotes to `We just changed our first Camel K integration while it was running!`. 
+Change the message sent to the `.simple()` command of the Camel route in quotes to **We just changed our first Camel K integration while it was running!**. 
 
 Save the file. Doing so automatically redeploys the file while it is deployed in Dev Mode. You should see the updated message displayed in the Output channel. 
 


### PR DESCRIPTION
it was using style of mentioning UI text or specific naming.

on master:
![Screenshot from 2020-06-08 11-51-20](https://user-images.githubusercontent.com/1105127/84017010-64c7a380-a97e-11ea-931f-3cdad525396a.png)
with this PR:
![Screenshot from 2020-06-08 11-50-53](https://user-images.githubusercontent.com/1105127/84016999-62654980-a97e-11ea-9e51-5b609e8068ab.png)

