### PR TITLE
FUSETOOLS2-487 - upgrade default kamel from 1.0.0-RC2 to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   # Download and provide in path minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.9.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
   # Download and provide in path kamel.
-  - curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/1.0.0-RC2/camel-k-client-1.0.0-RC2-linux-64bit.tar.gz
+  - curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/1.0.0/camel-k-client-1.0.0-linux-64bit.tar.gz
   - tar -zxvf kamel.tar.gz
   - chmod +x kamel
   - sudo mv kamel /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.14
 
+- Update default runtime version to 1.0.0
 - Listing VS Code task to deploy Camel K integration in "Start Apache Camel Integration" command
 - Completion for trait names and trait properties in tasks.json
 - Command to create new Apache Camel K Integration files

--- a/configure-minikube-camelk.md
+++ b/configure-minikube-camelk.md
@@ -3,7 +3,7 @@
 Before using the Tooling for Apache Camel K VS Code extension, both [Minikube](https://kubernetes.io/docs/setup/minikube/) and [Apache Camel K](https://camel.apache.org/camel-k/latest/index.html) must be installed on the local machine.
 
 * To install Minikube, follow the directions [here](https://camel.apache.org/camel-k/latest/installation/minikube.html).
-* To install Camel-K, grab the latest release (such as [1.0.0-M1](https://github.com/apache/camel-k/releases), copy it into a folder on the machine, and make that folder accessible on the system path.
+* To install Camel-K, grab the latest release (such as [1.0.0](https://github.com/apache/camel-k/releases), copy it into a folder on the machine, and make that folder accessible on the system path.
 
 Once Minikube and Apache Camel K are installed, follow the steps [here](https://camel.apache.org/camel-k/latest/installation/installation.html#procedure).
 

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -25,7 +25,7 @@ export var areJavaDependenciesDownloaded = false;
 export function downloadJavaDependencies(context:vscode.ExtensionContext): string {
     let pomTemplate = context.asAbsolutePath(path.join('resources', 'maven-project', 'pom-to-copy-java-dependencies.xml'));
     let extensionStorage = context.globalStoragePath;
-    let camelVersion = "3.0.1";
+    let camelVersion = "3.3.0";
 
     let destination = path.join(extensionStorage, `java-dependencies-${camelVersion}`);
     fs.mkdirSync(destination, { recursive: true });

--- a/src/kamel.ts
+++ b/src/kamel.ts
@@ -79,13 +79,14 @@ async function kamelInternal(command: string, devMode: boolean, namespace : stri
 		}
 		const cmd = getBaseCmd(binpath, command, namespace);
 		const sr = exec(cmd);
+		let wholeOutData = '';
 		if (sr) {
 			if (sr.stdout) {
 				sr.stdout.on('data', function (data) {
 					if (devMode && devMode === true) {
 						utils.shareMessage(extension.mainOutputChannel, `Dev Mode -- ${data}`);
 					}
-					resolve(data);
+					wholeOutData += data;
 				});
 			}        
 			if (sr.stderr) {
@@ -97,7 +98,11 @@ async function kamelInternal(command: string, devMode: boolean, namespace : stri
 			sr.on('close', function (exitCode) {
 				const exitCodeAsString = exitCode.toString();
 				if(exitCode === 0){
-					resolve(exitCodeAsString);
+					if(wholeOutData !== ''){
+						resolve(wholeOutData);
+					} else {
+						resolve(exitCodeAsString);
+					}
 				} else {
 					reject(new Error(exitCodeAsString));
 				}

--- a/src/task/TraitManager.ts
+++ b/src/task/TraitManager.ts
@@ -61,6 +61,15 @@ export class TraitManager {
 	private static async retrieveTraitsDefinitions(traitName?: string): Promise<TraitDefinition[]> {
 		const kamelExe = kamel.create();
 		const trait = await kamelExe.invoke(`help trait ${traitName ? traitName : '--all'} -o json`);
-		return JSON.parse(trait) as TraitDefinition[];
+		const sanitizedTrait = sanitizeToWorkaroundBugInKamel1_0_0(trait);
+		return JSON.parse(sanitizedTrait) as TraitDefinition[];
 	}
+}
+
+function sanitizeToWorkaroundBugInKamel1_0_0(trait: string) {
+	const indexOfJSonStart = trait.indexOf('[{"');
+	if (indexOfJSonStart > 0) {
+		trait = trait.substring(indexOfJSonStart, trait.length);
+	}
+	return trait;
 }

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -56,7 +56,7 @@ suite("Camel K Task Completion", function () {
     ]
 }`;
 		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236, new vscode.Position(9,24));
-		expect(res).to.have.lengthOf(26);
+		expect(res).to.have.lengthOf(28);
 		const affinityCompletionItem = res.find(item => item.label === 'affinity');
 		const affinitySnippet = affinityCompletionItem?.insertText as vscode.SnippetString;
 		expect(affinitySnippet.value).equals('"affinity.${1|enabled,pod-affinity,pod-anti-affinity,node-affinity-labels,pod-affinity-labels,pod-anti-affinity-labels|}="');

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -23,12 +23,12 @@ import * as kamelCli from './kamel';
 import { platformString, kamelUnavailableRejection } from './installer';
 import fetch from 'cross-fetch';
 
-export const version: string = '1.0.0-RC2'; //need to retrieve this if possible, but have a default
+export const version: string = '1.0.0'; //need to retrieve this if possible, but have a default
 /*
 * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searching for "last-modified" attribute
 * To be updated when updating the default "version" attribute
 */
-const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Fri, 28 Feb 2020 07:24:17 GMT';
+const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Tue, 09 Jun 2020 12:59:21 GMT';
 let latestVersionFromOnline: string;
 
 async function testVersionAvailable(versionToUse: string): Promise<boolean> {


### PR DESCRIPTION
- update the default value
- update last version time
- provide a workaround for bug
https://github.com/apache/camel-k/issues/1511 . it includes a "sanitize"
of the retrieved string by removing the extra yaml returned. given that
the size of the returned string is higher than 65536, the output is send
in 2 chunks, which requires to improve the kamel command call in our
codde
- update number of traits available in traits

Signed-off-by: Aurélien Pupier <apupier@redhat.com>