### PR TITLE
FUSETOOLS2-207 - reactivate Java completion tests on Jenkins

### DIFF
--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -23,7 +23,6 @@ import { getDocUri, checkExpectedCompletion } from '../completion.util';
 import { fail } from 'assert';
 import * as Utils from '../Utils';
 
-const os = require('os');
 const waitUntil = require('async-wait-until');
 
 const DOWNLOAD_JAVA_DEPENDENCIES_TIMEOUT = 240000;
@@ -36,10 +35,7 @@ suite('Should do completion in Camel K standalone files', () => {
 
 	const expectedCompletion = { label: 'from(String uri) : RouteDefinition'};
 
-	var testVar = test('Completes from method for Java', async () => {
-		if(os.homedir().includes('hudson')) {
-			testVar.skip();
-		}
+	test('Completes from method for Java', async () => {
 		await testCompletion(docUriJava, new vscode.Position(5, 11), expectedCompletion);
 	}).timeout(TOTAL_TIMEOUT);
 


### PR DESCRIPTION
after rework of the test fo r1.0.0, seems we can now reactivate the test on Jenkins

https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/VS%20Code/job/vscode-temporary-testing/49/console
```
 Should do completion in Camel K standalone files

      ✓ Completes from method for Java: 12590ms
```