### PR TITLE
FUSETOOLS2-604 - Upgrade Java on Jenkins to Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node('rhel8'){
 	}
 
 	stage('Build') {
-		env.JAVA_HOME="${tool 'openjdk-1.8'}"
+		env.JAVA_HOME="${tool 'openjdk-11'}"
 		env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
 		sh "java -version"
 		


### PR DESCRIPTION
as it is required now for VS Code java and so Ui tests

Signed-off-by: Aurélien Pupier <apupier@redhat.com>