### PR TITLE
FUSETOOLS2-709 - fix broken master after Camel K 1.1.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   # Download and provide in path minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.9.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
   # Download and provide in path kamel.
-  - curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.1.0/camel-k-client-1.1.0-linux-64bit.tar.gz
+  - curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.1.1/camel-k-client-1.1.1-linux-64bit.tar.gz
   - tar -zxvf kamel.tar.gz
   - chmod +x kamel
   - sudo mv kamel /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.17
 
 - Associate Yaml Camel K schema when there is the Camel K modeline. The associated schema is configurable in the settings.
+- Update default runtime version to v1.1.1
 
 ## 0.0.16
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 					},
 					"camelk.integrations.runtimeVersion": {
 						"type": "string",
-						"description": "Default Apache Camel K Runtime Version (for example 1.1.0)",
+						"description": "Default Apache Camel K Runtime Version (for example 1.1.1)",
 						"scope": "window"
 					},
 					"camelk.integrations.autoUpgrade": {

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 const PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES = "java.project.referencedLibraries";
-export const CAMEL_VERSION = "3.3.0";
+export const CAMEL_VERSION = "3.5.0";
 
 export function downloadJavaDependencies(context: vscode.ExtensionContext): string {
 	const pomTemplate = context.asAbsolutePath(path.join('resources', 'maven-project', 'pom-to-copy-java-dependencies.xml'));

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -36,6 +36,10 @@ suite("ensure version url methods are functioning as expected", () => {
 	test("validate url for existing 1.1.0 version", async () => {
 		await validateVersion('1.1.0', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.1.0/camel-k-client-1.1.0-linux-64bit.tar.gz');
 	});
+	
+	test("validate url for existing 1.1.1 version", async () => {
+		await validateVersion('1.1.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.1.1/camel-k-client-1.1.1-linux-64bit.tar.gz');
+	});
 
 	test("validate invalid url for xyz1 version", async () => {
 		await invalidateVersion('xyz1', 'linux');

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -24,13 +24,13 @@ import * as kamelCli from './kamel';
 import { platformString } from './installer';
 import fetch from 'cross-fetch';
 
-export const version: string = '1.1.0'; //need to retrieve this if possible, but have a default
+export const version: string = '1.1.1'; //need to retrieve this if possible, but have a default
 
 /*
 * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searching for "last-modified" attribute
 * To be updated when updating the default "version" attribute
 */
-const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Monday, 27 Jul 2020 19:27:00 GMT';
+const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Tue, 15 Sep 2020 10:27:14 GMT';
 let latestVersionFromOnline: string;
 
 export async function testVersionAvailable(versionToUse: string): Promise<boolean> {


### PR DESCRIPTION
The fix consists in upgrading the default version.

I created https://issues.redhat.com/browse/FUSETOOLS2-713 to try to avoid breaking the master.
I created https://github.com/camel-tooling/vscode-camelk/pull/552 to have a clearer error message at least

we can notice that the test is passing https://travis-ci.org/github/camel-tooling/vscode-camelk/builds/729237598#L968 This is checked via separate temporary branch/[PR](https://github.com/camel-tooling/vscode-camelk/pull/556) because the test requires to have access to github token.