### PR TITLE
FUSETOOLS2-754 - support space in path for default provided task

### DIFF
--- a/src/task/CamelKTaskDefinition.ts
+++ b/src/task/CamelKTaskDefinition.ts
@@ -58,7 +58,7 @@ export class CamelKTaskProvider implements vscode.TaskProvider {
 		let taskDefinition = {
 			"type": CamelKTaskProvider.START_CAMELK_TYPE,
 			"label": "Start in dev mode Camel K integration opened in active editor",
-			"file": "${file}",
+			"file": "\"${file}\"",
 			"dev": true
 		};
 		this.tasks.push(this.getTask(taskDefinition));


### PR DESCRIPTION
- create folder with a space in path
- create an Integration file in this folder
- Call command "Start Integration"
- choose "task"
- choose the default one called "Start in dev mode Camel K integration opened in active editor"

test covering this use case provided in this PR https://github.com/camel-tooling/vscode-camelk/pull/571