### PR TITLE
FUSETOOLS2-222 - support task also when kamel is not on user path

### DIFF
--- a/src/task/CamelKTaskDefinition.ts
+++ b/src/task/CamelKTaskDefinition.ts
@@ -16,6 +16,7 @@
  */
 'use strict';
 
+import * as kamel from '../kamel';
 import * as vscode from 'vscode';
 import * as IntegrationUtils from '../IntegrationUtils';
 
@@ -36,7 +37,7 @@ export interface CamelKTaskDefinition extends vscode.TaskDefinition {
 }
 
 export class CamelKTaskProvider implements vscode.TaskProvider {
-
+	
 	private tasks: vscode.Task[] | undefined;
 	static START_CAMELK_TYPE: string = 'camel-k';
 	constructor() { }
@@ -45,12 +46,12 @@ export class CamelKTaskProvider implements vscode.TaskProvider {
 		return this.getTasks();
 	}
 
-	public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+	public async resolveTask(_task: vscode.Task): Promise<vscode.Task | undefined> {
 		const definition: CamelKTaskDefinition = <any>_task.definition;
-		return this.getTask(definition);
+		return await this.getTask(definition);
 	}
 
-	private getTasks(): vscode.Task[] {
+	private async getTasks(): Promise<vscode.Task[]> {
 		if (this.tasks !== undefined) {
 			return this.tasks;
 		}
@@ -61,11 +62,11 @@ export class CamelKTaskProvider implements vscode.TaskProvider {
 			"file": "${file}",
 			"dev": true
 		};
-		this.tasks.push(this.getTask(taskDefinition));
+		this.tasks.push(await this.getTask(taskDefinition));
 		return this.tasks;
 	}
 
-	public getTask(definition: CamelKTaskDefinition): vscode.Task {
+	public async getTask(definition: CamelKTaskDefinition): Promise<vscode.Task> {
 		let args = IntegrationUtils.computeKamelArgs(definition.file,
 			definition.dev,
 			definition.configmap,
@@ -79,7 +80,7 @@ export class CamelKTaskProvider implements vscode.TaskProvider {
 			definition.compression,
 			definition.profile);
 		let argsInlined = args.join(' ');
-		let processExecution = new vscode.ShellExecution(`kamel ${argsInlined}`);
+		let processExecution = new vscode.ShellExecution(`${await kamel.create().getPath()} ${argsInlined}`);
 		let displayName :string;
 		if(definition.label) {
 			displayName = definition.label;

--- a/src/test/suite/CamelKTaskDefinition.test.ts
+++ b/src/test/suite/CamelKTaskDefinition.test.ts
@@ -22,151 +22,139 @@ import { assert } from "chai";
 
 suite("Camel K Task definition", function() {
 
-    test("ensure include configmap", function(done) {
+    test("ensure include configmap", async() => {
         let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "configmap": "aDummyConfigMapId",
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--configmap=aDummyConfigMapId');
-        done();
     });
 
-    test("ensure include compression flag", function(done) {
+    test("ensure include compression flag", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "compression": true,
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--compression');
-        done();
     });
 
-    test("ensure include dependencies", function(done) {
+    test("ensure include dependencies", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "dependencies": ["camel.mina2", "mvn:com.google.guava:guava:26.0-jre"],
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--dependency=camel.mina2');
         assert.include(execution.commandLine, '--dependency=mvn:com.google.guava:guava:26.0-jre');
-        done();
     });
 
-    test("ensure include dev flag", function(done) {
+    test("ensure include dev flag", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "dev": true,
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--dev');
-        done();
     });
 
-    test("ensure include Environment variables", function(done) {
+    test("ensure include Environment variables", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "environmentVariables": ["MY_ENV=value", "MY_ENV2=value2"],
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '-e MY_ENV=value');
         assert.include(execution.commandLine, '-e MY_ENV2=value2');
-        done();
     });
 
-    test("ensure include target file", function(done) {
+    test("ensure include target file", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, 'dummyFileValue.xml');
-        done();
     });
 
-    test("ensure include profile", function(done) {
+    test("ensure include profile", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "profile": "adummyprofile",
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--profile=adummyprofile');
-        done();
     });
 
-    test("ensure include properties", function(done) {
+    test("ensure include properties", async() => {
         let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "properties": ["prop1=value1", "prop2=value2"],
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '-p prop1=value1');
         assert.include(execution.commandLine, '-p prop2=value2');
-        done();
     });
 
-    test("ensure include resource", function(done) {
+    test("ensure include resource", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "resource": "adummyresource",
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--resource="adummyresource"');
-        done();
     });
 
-    test("ensure include secret", function(done) {
+    test("ensure include secret", async() => {
 		let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "secret": "adummysecret",
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '--secret=adummysecret');
-        done();
     });
     
-    test("ensure include traits", function(done) {
+    test("ensure include traits", async() => {
         let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "traits": ["camel.enabled=true", "camel.runtime-version=3.0.0"],
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '-t camel.enabled=true');
         assert.include(execution.commandLine, '-t camel.runtime-version=3.0.0');
-        done();
     });
     
-    test("ensure include volumes", function(done) {
+    test("ensure include volumes", async() => {
         let def: CamelKTaskDefinition = {
             "file" : "dummyFileValue.xml",
             "volumes": ["pvcname:/container/path", "pvcname:/container/path2"],
             "type": CamelKTaskProvider.START_CAMELK_TYPE
         };
-        let task = new CamelKTaskProvider().getTask(def);
+        const task = await new CamelKTaskProvider().getTask(def);
         let execution = task.execution as ShellExecution;
         assert.include(execution.commandLine, '-v pvcname:/container/path');
         assert.include(execution.commandLine, '-v pvcname:/container/path2');
-        done();
     });
 });


### PR DESCRIPTION
test covering this use case provided in this PR https://github.com/camel-tooling/vscode-camelk/pull/571