### PR TITLE
FUSETOOLS2-780 - upgrade default version to Camel K 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   # Download and provide in path minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.13.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
   # Download and provide in path kamel.
-  - curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.1.1/camel-k-client-1.1.1-linux-64bit.tar.gz
+  - curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.2.0/camel-k-client-1.2.0-linux-64bit.tar.gz
   - tar -zxvf kamel.tar.gz
   - chmod +x kamel
   - sudo mv kamel /usr/local/bin/

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 					},
 					"camelk.integrations.runtimeVersion": {
 						"type": "string",
-						"description": "Default Apache Camel K Runtime Version (for example 1.1.1)",
+						"description": "Default Apache Camel K Runtime Version (for example 1.2.0)",
 						"scope": "window"
 					},
 					"camelk.integrations.autoUpgrade": {

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -56,7 +56,7 @@ suite("Camel K Task Completion", function () {
     ]
 }`;
 		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236, new vscode.Position(9,24));
-		expect(res).to.have.lengthOf(28);
+		expect(res).to.have.lengthOf(29);
 		const affinityCompletionItem = res.find(item => item.label === 'affinity');
 		const affinitySnippet = affinityCompletionItem?.insertText as vscode.SnippetString;
 		expect(affinitySnippet.value).equals('"affinity.${1|enabled,pod-affinity,pod-anti-affinity,node-affinity-labels,pod-affinity-labels,pod-anti-affinity-labels|}="');

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -40,6 +40,10 @@ suite("ensure version url methods are functioning as expected", () => {
 	test("validate url for existing 1.1.1 version", async () => {
 		await validateVersion('1.1.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.1.1/camel-k-client-1.1.1-linux-64bit.tar.gz');
 	});
+	
+	test("validate url for existing 1.2.0 version", async () => {
+		await validateVersion('1.2.0', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.2.0/camel-k-client-1.2.0-linux-64bit.tar.gz');
+	});
 
 	test("validate invalid url for xyz1 version", async () => {
 		await invalidateVersion('xyz1', 'linux');

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -24,13 +24,13 @@ import * as kamelCli from './kamel';
 import { platformString } from './installer';
 import fetch from 'cross-fetch';
 
-export const version: string = '1.1.1'; //need to retrieve this if possible, but have a default
+export const version: string = '1.2.0'; //need to retrieve this if possible, but have a default
 
 /*
 * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searching for "last-modified" attribute
 * To be updated when updating the default "version" attribute
 */
-const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Tue, 15 Sep 2020 10:27:14 GMT';
+const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Mon, 12 Oct 2020 10:49:47 GMT';
 let latestVersionFromOnline: string;
 
 export async function testVersionAvailable(versionToUse: string): Promise<boolean> {


### PR DESCRIPTION
nota: the version of Camel dependencies is still the same 3.5.0
https://github.com/apache/camel-k-runtime/blob/f52b4c4e37ef9c6c3f5ad3b3929e220f7fe63b12/pom.xml#L41

Signed-off-by: Aurélien Pupier <apupier@redhat.com>