### PR TITLE
FUSETOOLS2-878 - update link to Camel K schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 					},
 					"camelk.yaml.schema": {
 						"type": "string",
-						"default": "https://raw.githubusercontent.com/apache/camel-k-runtime/master/camel-k-loader-yaml/camel-k-loader-yaml/src/generated/resources/camel-yaml-dsl.json",
+						"default": "https://raw.githubusercontent.com/apache/camel-k-runtime/camel-k-runtime-parent-1.5.0/camel-k-loader-yaml/camel-k-loader-yaml/src/generated/resources/camel-yaml-dsl.json",
 						"description": "Yaml Schema applied when Camel K modeline is set. (I.e. file starting with '# camel-k: ')"
 					}
 				}

--- a/src/CamelKSchemaManager.ts
+++ b/src/CamelKSchemaManager.ts
@@ -57,8 +57,9 @@ async function retrieveSchemaAsCache(mainOutputChannel: vscode.OutputChannel): P
 		if (schemaUrl !== undefined) {
 			const res: Response = await fetch(schemaUrl);
 			if (res.status >= 400) {
-				console.log('error fetching: '+ res.statusText);
-				mainOutputChannel.appendLine('Cannot retrieve Camel K schema. ' + res.statusText);
+				const errorMessage = `Cannot retrieve Camel K schema from url ${schemaUrl} with status text ${res.statusText} and error code ${res.status}`;
+				console.log(errorMessage);
+				mainOutputChannel.appendLine(errorMessage);
 				return undefined;
 			} else if (camelkSchemaCache === undefined) {
 				camelkSchemaCache = await res.text();


### PR DESCRIPTION
we were pointing to master as it was implemented when there was no tag
available yet. it was refactored on master. So pointing to latest tag.
It will avoid breakage from external part but requires more maintenance.

including more traces in log too for next time, it will be easier to
debug (see https://travis-ci.com/github/camel-tooling/vscode-camelk/builds/202096761#L391 for instance)