### PR TITLE
FUSETOOLS2-857 - Add Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,94 @@
+version: 2.1
+ 
+jobs:
+  build:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Install Node environment
+          command: |
+            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+      - run:
+          name: install-vsce
+          command: sudo npm install -g vsce
+      - run:
+          name: npm-ci
+          command: npm ci
+      - run:
+          name: npm-vscode:prepublish
+          command: npm run vscode:prepublish
+      - run:
+          name: vsce-package
+          command: vsce package
+      - run:
+          name: Setup Environment Variables for Minikube
+          command: |
+            echo 'export HOME=/home/circleci' >> $BASH_ENV
+            echo 'export MINIKUBE_WANTUPDATENOTIFICATION=false' >> $BASH_ENV
+            echo 'export MINIKUBE_WANTREPORTERRORPROMPT=false' >> $BASH_ENV
+            echo 'export MINIKUBE_HOME=$HOME' >> $BASH_ENV
+            echo 'export KUBECONFIG=$HOME/.kube/config' >> $BASH_ENV
+      - run:
+          name: Configure Minikube
+          command: |               
+            sudo apt-get -qq -y install conntrack iptables 
+            # Download and provide in path kubectl , which is a requirement for using minikube.
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+            # Download and provide in path minikube.
+            curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.15.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+            mkdir -p $HOME/.kube $HOME/.minikube
+            touch $KUBECONFIG
+            minikube start --vm-driver=docker --kubernetes-version=v1.19.0
+            minikube addons enable registry
+            sudo chown -R circleci: /home/circleci/.minikube/
+            kubectl cluster-info
+            # Clean CLI which were used to start the Kubernetes instance
+            sudo rm /usr/local/bin/minikube
+            sudo rm /usr/local/bin/kubectl
+      - run:
+          name: Configure Kamel
+          command: |               
+            # Download and provide in path kamel.
+            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.2.0/camel-k-client-1.2.0-linux-64bit.tar.gz
+            tar -zxvf kamel.tar.gz
+            chmod +x kamel
+            sudo mv kamel /usr/local/bin/
+            kamel install
+            # Clean CLI which were used to start the Kubernetes instance
+            sudo rm /usr/local/bin/kamel
+      - run:
+          name: test
+          command: npm test
+      - run:
+          name: test UI
+          command: npm run ui-test
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.npm
+      - store_artifacts:
+          path: /home/circleci/.config/Code/logs
+          name: Store VS Code logs
+      - store_artifacts:
+          path: /home/circleci/.config/Code/User/workspaceStorage/
+          name: Store VS Code User Workspace storage
+      - when:
+          condition:
+            equal: [master, << pipeline.git.branch >>]
+          steps:
+            - sonarcloud/scan
+
+orbs:
+  sonarcloud: sonarsource/sonarcloud@1.0.2
+
+workflows:
+  version: 2
+  vscode-camelk:
+    jobs:
+      - build:
+          context: sonarcloud

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.sources=src
 sonar.exclusions=src/test/**
 sonar.tests=src/test
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.organization=camel-tooling
 
 sonar.links.homepage=https://github.com/camel-tooling/vscode-camelk
 sonar.links.ci=https://travis-ci.org/camel-tooling/vscode-camelk


### PR DESCRIPTION
- use image to have a privileged Docker access required by minikube.
Using the docker vm-driver which is the only one which seems to work
(available in latest minikube)
- increase timeout for one test as it is takingmore time on Circle CI
- some artifacts are uploaded: it is log of VS Code and the VS Code User
Storage. Useful for debugging
- steps ordered to compile before installing requirements for test that
are taking a long time

Signed-off-by: Aurélien Pupier <apupier@redhat.com>