### PR TITLE
FUSETOOLS2-929 - upgrade to Camel K 1.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Configure Kamel
           command: |               
             # Download and provide in path kamel.
-            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.2.1/camel-k-client-1.2.1-linux-64bit.tar.gz
+            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.3.0/camel-k-client-1.3.0-linux-64bit.tar.gz
             tar -zxvf kamel.tar.gz
             chmod +x kamel
             sudo mv kamel /usr/local/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Configure Kamel
           command: |               
             # Download and provide in path kamel.
-            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.3.0/camel-k-client-1.3.0-linux-64bit.tar.gz
+            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.3.1/camel-k-client-1.3.1-linux-64bit.tar.gz
             tar -zxvf kamel.tar.gz
             chmod +x kamel
             sudo mv kamel /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.21
 
+- Update default runtime version to v1.3.1
+
 ## 0.0.20
 
 - Change default of `auto-update` of kamel cli binary from `true` to `false`. It avoids that Camel K regressions are breaking the extension.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 					},
 					"camelk.integrations.runtimeVersion": {
 						"type": "string",
-						"description": "Default Apache Camel K Runtime Version (for example 1.2.1)",
+						"description": "Default Apache Camel K Runtime Version (for example 1.3.0)",
 						"scope": "window"
 					},
 					"camelk.integrations.autoUpgrade": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 					},
 					"camelk.integrations.runtimeVersion": {
 						"type": "string",
-						"description": "Default Apache Camel K Runtime Version (for example 1.3.0)",
+						"description": "Default Apache Camel K Runtime Version (for example 1.3.1)",
 						"scope": "window"
 					},
 					"camelk.integrations.autoUpgrade": {

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 const PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES = "java.project.referencedLibraries";
-export const CAMEL_VERSION = "3.5.0";
+export const CAMEL_VERSION = "3.7.0";
 
 export function downloadJavaDependencies(context: vscode.ExtensionContext): string {
 	const pomTemplate = context.asAbsolutePath(path.join('resources', 'maven-project', 'pom-to-copy-java-dependencies.xml'));

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -56,7 +56,7 @@ suite("Camel K Task Completion", function () {
     ]
 }`;
 		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236, new vscode.Position(9,24));
-		expect(res).to.have.lengthOf(29);
+		expect(res).to.have.lengthOf(30);
 		const affinityCompletionItem = res.find(item => item.label === 'affinity');
 		const affinitySnippet = affinityCompletionItem?.insertText as vscode.SnippetString;
 		expect(affinitySnippet.value).equals('"affinity.${1|enabled,pod-affinity,pod-anti-affinity,node-affinity-labels,pod-affinity-labels,pod-anti-affinity-labels|}="');

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -44,6 +44,10 @@ suite("ensure version url methods are functioning as expected", () => {
 	test("validate url for existing 1.2.1 version", async () => {
 		await validateVersion('1.2.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.2.1/camel-k-client-1.2.1-linux-64bit.tar.gz');
 	});
+	
+	test("validate url for existing 1.3.0 version", async () => {
+		await validateVersion('1.3.0', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.3.0/camel-k-client-1.3.0-linux-64bit.tar.gz');
+	});
 
 	test("validate invalid url for xyz1 version", async () => {
 		await invalidateVersion('xyz1', 'linux');

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -45,8 +45,8 @@ suite("ensure version url methods are functioning as expected", () => {
 		await validateVersion('1.2.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.2.1/camel-k-client-1.2.1-linux-64bit.tar.gz');
 	});
 	
-	test("validate url for existing 1.3.0 version", async () => {
-		await validateVersion('1.3.0', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.3.0/camel-k-client-1.3.0-linux-64bit.tar.gz');
+	test("validate url for existing 1.3.1 version", async () => {
+		await validateVersion('1.3.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.3.1/camel-k-client-1.3.1-linux-64bit.tar.gz');
 	});
 
 	test("validate invalid url for xyz1 version", async () => {

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -24,7 +24,7 @@ import * as kamelCli from './kamel';
 import { platformString } from './installer';
 import fetch from 'cross-fetch';
 
-export const version: string = '1.2.1'; //need to retrieve this if possible, but have a default
+export const version: string = '1.3.0'; //need to retrieve this if possible, but have a default
 
 /*
 * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searching for "last-modified" attribute

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -24,13 +24,13 @@ import * as kamelCli from './kamel';
 import { platformString } from './installer';
 import fetch from 'cross-fetch';
 
-export const version: string = '1.3.0'; //need to retrieve this if possible, but have a default
+export const version: string = '1.3.1'; //need to retrieve this if possible, but have a default
 
 /*
 * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest` and searching for "last-modified" attribute
 * To be updated when updating the default "version" attribute
 */
-const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Fri, 27 Nov 2020 08:56:01 GMT';
+const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Thu, 04 Jan 2021 15:05:35 GMT';
 let latestVersionFromOnline: string;
 
 export async function testVersionAvailable(versionToUse: string): Promise<boolean> {


### PR DESCRIPTION
- not updated the versionUtil.LAST_MODIFIED_DATE_OF_DEFAULT_VERSION
because the release is missing on github
https://camel.zulipchat.com/#narrow/stream/257299-camel-k/topic/Missing.201.2E3.2E0.20release.20on.20Github/near/221051887
- support of new features such as debug and local deployment command to
be added in a separated PR

Signed-off-by: Aurélien Pupier <apupier@redhat.com>