### PR TITLE
FUSETOOLS2-952 - avoid automatic upgrade by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 					},
 					"camelk.integrations.autoUpgrade": {
 						"type": "boolean",
-						"default": true,
+						"default": false,
 						"description": "Automatically upgrade Apache Camel K Runtime CLI when new CLI version is released",
 						"scope": "window"
 					},


### PR DESCRIPTION
it avoids to upgrade to broken version like Camel K 1.3.0

Signed-off-by: Aurélien Pupier <apupier@redhat.com>