### PR TITLE
FUSETOOLS2-954 - due to Minikube wrong latest .deb distributed, specify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
       - run:
           name: Configure Minikube
           command: |
-            curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
-            sudo dpkg -i minikube_latest_amd64.deb
+            curl -LO https://github.com/kubernetes/minikube/releases/download/v1.16.0/minikube_1.16.0-1_amd64.deb
+            sudo dpkg -i minikube_1.16.0-1_amd64.deb
             minikube start --vm-driver=docker --kubernetes-version=v1.19.0
             minikube addons enable registry
       - run:


### PR DESCRIPTION
a specific version

see https://github.com/kubernetes/minikube/issues/10224
