### PR TITLE
Mandatory PRs to fix master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
       - run:
           name: Configure Minikube
           command: |
-            curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
-            sudo dpkg -i minikube_latest_amd64.deb
+            curl -LO https://github.com/kubernetes/minikube/releases/download/v1.16.0/minikube_1.16.0-1_amd64.deb
+            sudo dpkg -i minikube_1.16.0-1_amd64.deb
             minikube start --vm-driver=docker --kubernetes-version=v1.19.0
             minikube addons enable registry
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.20
 
-
+- Change default of `auto-update` of kamel cli binary from `true` to `false`. It avoids that Camel K regressions are breaking the extension.
 
 ## 0.0.19
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 					},
 					"camelk.integrations.autoUpgrade": {
 						"type": "boolean",
-						"default": true,
+						"default": false,
 						"description": "Automatically upgrade Apache Camel K Runtime CLI when new CLI version is released",
 						"scope": "window"
 					},


### PR DESCRIPTION
2 PRS are mandatory due to 2 external problems that break the master, grouping the 2 inthis PR to have a green build:
https://github.com/camel-tooling/vscode-camelk/pull/652
https://github.com/camel-tooling/vscode-camelk/pull/650

Having the 2 other PRs can ease review of the ùmodifications but I think that th emerge need to be doen from this one
