### PR TITLE
FUSETOOLS-1035 - provide basic telemetry for most commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.22
 
-- Provide opt-in telemetry to gather information on Camel K integration created through provided command
+- Provide opt-in telemetry to gather information on Camel K integration created through provided command and most command ids.
 
 ## 0.0.21
 

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -3,5 +3,6 @@
 ### Usage Data
 
 * when extension is activated
+* when a command from this extension is used, the command id is provided
 * when `Create a new Apache Camel K Integration file` command contributed by extension is executed
     * with the chosen language

--- a/src/ConfigMapAndSecrets.ts
+++ b/src/ConfigMapAndSecrets.ts
@@ -22,24 +22,33 @@ import * as extension from './extension';
 import * as utils from './CamelKJSONUtils';
 import { isKubernetesAvailable } from './kubectlutils';
 import { ShellResult } from './shell';
+import * as telemetry from './Telemetry';
 
 export const validNameRegex: RegExp = /^[A-Za-z][A-Za-z0-9\-]*(?:[A-Za-z0-9]$){1}/;
+const COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE = 'camelk.integrations.createconfigmapfromfile';
+const COMMAND_ID_CREATE_CONFIGMAP_FROM_FOLDER = 'camelk.integrations.createconfigmapfromfolder';
+const COMMAND_ID_CREATE_SECRET_FROM_FILE = 'camelk.integrations.createsecretfromfile';
+const COMMAND_ID_CREATE_SECRET_FROM_FOLDER = 'camelk.integrations.createsecretfromfolder';
 
 export function registerCommands(): void {
 	// create the integration view action -- create new configmap from file or folder
-	vscode.commands.registerCommand('camelk.integrations.createconfigmapfromfile', (uri:vscode.Uri) => {
+	vscode.commands.registerCommand(COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE, (uri:vscode.Uri) => {
 		createConfigMapFromUri(uri);
+		telemetry.sendCommandTracking(COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE);
 	});
-	vscode.commands.registerCommand('camelk.integrations.createconfigmapfromfolder', (uri:vscode.Uri) => {
+	vscode.commands.registerCommand(COMMAND_ID_CREATE_CONFIGMAP_FROM_FOLDER, (uri:vscode.Uri) => {
 		createConfigMapFromUri(uri);
+		telemetry.sendCommandTracking(COMMAND_ID_CREATE_CONFIGMAP_FROM_FOLDER);
 	});
 
 	// create the integration view action -- create new secret from file or folder
-	vscode.commands.registerCommand('camelk.integrations.createsecretfromfile', (uri:vscode.Uri) => {
+	vscode.commands.registerCommand(COMMAND_ID_CREATE_SECRET_FROM_FILE, (uri:vscode.Uri) => {
 		createSecretFromUri(uri);
+		telemetry.sendCommandTracking(COMMAND_ID_CREATE_SECRET_FROM_FILE);
 	});
-	vscode.commands.registerCommand('camelk.integrations.createsecretfromfolder', (uri:vscode.Uri) => {
+	vscode.commands.registerCommand(COMMAND_ID_CREATE_SECRET_FROM_FOLDER, (uri:vscode.Uri) => {
 		createSecretFromUri(uri);
+		telemetry.sendCommandTracking(COMMAND_ID_CREATE_SECRET_FROM_FOLDER);
 	});
 }
 

--- a/src/Telemetry.ts
+++ b/src/Telemetry.ts
@@ -15,11 +15,22 @@
  * limitations under the License.
  */
 
-import { TelemetryService, getTelemetryService } from "@redhat-developer/vscode-redhat-telemetry/lib";
+import { TelemetryService, getTelemetryService, TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
 
 
 export const telemetryService: Promise<TelemetryService> = getTelemetryService('redhat.vscode-camelk');
 
 export async function getTelemetryServiceInstance(): Promise<TelemetryService> {
     return telemetryService;
+}
+
+export async function sendCommandTracking(commandId: string) {
+	const telemetryEvent: TelemetryEvent = {
+		type: 'track',
+		name: 'command',
+		properties: {
+			identifier: commandId
+		}
+	};
+	(await telemetryService).send(telemetryEvent);
 }


### PR DESCRIPTION
- there is no existing test at top level of commands call. I have not
found how
to add an assertion without high complexity
- it is covering only "happy" case. In case of failure, no telemetry
reported in most case. In case of abortion of the command, a telemetry
event is reported without mentioning that user didn't go to the end of
the "wizard command"

https://snapshot.woopra.com/5GeHozdVXv4ujHQiSgQLcHBerREYPXSpGkCqLoJkd5rBWPKq3qjREgUCrjqDCdDqR3