### PR TITLE
FUSETOOLS2-1044 - remove several useless artifacts from vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,12 +1,18 @@
+.circleci
+.scannerwork
 .vscode/**
 .vscode-test/**
 out/test/**
 out/**/*.map
 src/**
 .gitignore
+Jenkinsfile
 tsconfig.json
 vsc-extension-quickstart.md
+sonar-project.properties
 tslint.json
+test Fixture with speci@l chars
 test-resources
 coverconfig.json
 coverage
+*.vsix


### PR DESCRIPTION
especially the test fixture which are taking hundreds of Mo
uncompressed, around 30 Mo compressed in the vsix

Signed-off-by: Aurélien Pupier <apupier@redhat.com>