### PR TITLE
Update VS Code extension tester to 4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,16 +1011,14 @@
 			}
 		},
 		"clone-deep": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-			"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.3",
-				"is-plain-object": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"lazy-cache": "^1.0.3",
-				"shallow-clone": "^0.1.2"
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
 			}
 		},
 		"clone-response": {
@@ -1721,9 +1719,9 @@
 			}
 		},
 		"domutils": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-			"integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
+			"integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
 			"dev": true,
 			"requires": {
 				"dom-serializer": "^1.0.1",
@@ -2000,21 +1998,6 @@
 			"version": "1.13.3",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
 			"integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
-		},
-		"for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
-			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -2326,9 +2309,9 @@
 			"dev": true
 		},
 		"htmlparser2": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
-			"integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
+			"integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
 			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
@@ -2447,12 +2430,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
 			"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
-			"dev": true
-		},
-		"is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
 		},
 		"is-extglob": {
@@ -2737,18 +2714,9 @@
 			}
 		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5"
-			}
-		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
 		"lcid": {
@@ -3010,16 +2978,6 @@
 				}
 			}
 		},
-		"merge-deep": {
-			"version": "github:jrichter1/merge-deep#9ffe23b32f281de41bce111e8c38294d96fed34e",
-			"from": "github:jrichter1/merge-deep#functions",
-			"dev": true,
-			"requires": {
-				"arr-union": "^3.1.0",
-				"clone-deep": "^0.2.4",
-				"kind-of": "^3.0.2"
-			}
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3083,24 +3041,6 @@
 			"requires": {
 				"minipass": "^3.0.0",
 				"yallist": "^4.0.0"
-			}
-		},
-		"mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"dependencies": {
-				"for-in": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-					"dev": true
-				}
 			}
 		},
 		"mkdirp": {
@@ -3264,15 +3204,15 @@
 			}
 		},
 		"monaco-page-objects": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.4.2.tgz",
-			"integrity": "sha512-XcZ8ZCAUTfRdr6ZDanBQ2JIipP0YtTcdoBCNHlen6ZkKd1a8YoWJvn86fbJ2wxSe3w0orHvQcGAT/fBWIKZ3iQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.5.1.tgz",
+			"integrity": "sha512-5/1Zq89TowF8gn6f3Dw+RaEeDCeTZU5rT+jwsqKMk6mtCl4BRUDxQSGW7QRZNUqhf0HUWbomerCRdxSwjsOP+A==",
 			"dev": true,
 			"requires": {
 				"clipboardy": "^2.0.0",
+				"clone-deep": "^4.0.1",
 				"compare-versions": "^3.5.1",
 				"fs-extra": "^9.0.1",
-				"merge-deep": "github:jrichter1/merge-deep#functions",
 				"ts-essentials": "^7.0.0"
 			}
 		},
@@ -4387,32 +4327,12 @@
 			"dev": true
 		},
 		"shallow-clone": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
 			"dev": true,
 			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^2.0.1",
-				"lazy-cache": "^0.2.3",
-				"mixin-object": "^2.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.0.2"
-					}
-				},
-				"lazy-cache": {
-					"version": "0.2.7",
-					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-					"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-					"dev": true
-				}
+				"kind-of": "^6.0.2"
 			}
 		},
 		"shebang-command": {
@@ -5188,9 +5108,9 @@
 			}
 		},
 		"vscode-extension-tester": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-3.2.6.tgz",
-			"integrity": "sha512-yhPkfUpgCxK5AdeqW0gsvDRquBixGgTb2BC6RgdaXHvi9pna7nomlwzDeLWNZkiT2p+Rg+bcF61ftggMER2gcQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-4.0.2.tgz",
+			"integrity": "sha512-g24GbeyRgx6SEtodtP1U3RShjX7y+A9i13OuSou3yyq/mVB6HyBGlEV7dLdctdSg45u7PfbLXpVZPy3C5jKQ9g==",
 			"dev": true,
 			"requires": {
 				"@types/selenium-webdriver": "^3.0.15",
@@ -5199,14 +5119,14 @@
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.6",
 				"js-yaml": "^3.13.1",
-				"monaco-page-objects": "^1.4.2",
+				"monaco-page-objects": "^1.5.1",
 				"request": "^2.88.0",
 				"sanitize-filename": "^1.6.3",
 				"selenium-webdriver": "^3.0.0",
 				"targz": "^1.0.1",
 				"unzip-stream": "^0.3.0",
 				"vsce": "^1.81.0",
-				"vscode-extension-tester-locators": "^1.53.0"
+				"vscode-extension-tester-locators": "^1.54.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -5218,9 +5138,9 @@
 			}
 		},
 		"vscode-extension-tester-locators": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.53.0.tgz",
-			"integrity": "sha512-/ObRO+/W3YLVFuH10qbSYivvBsXy+1z564Ka8H8HJ5TJBf0SG1IJzdJe2ocyeosD4OQLoNOWPhhQdrhZoHUkxw==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.54.0.tgz",
+			"integrity": "sha512-4coRvV38F0Qxmxq+MDAv3C573AfRgY1k8hPN+wB/98yF+ETOkafXt4GDgo1Mdf7XZxnNyRHWxGoqPUXFuKtY7A==",
 			"dev": true
 		},
 		"vscode-extension-tester-native": {

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
 		"sinon-chai": "^3.5.0",
 		"tslint": "^6.1.3",
 		"typescript": "^4.2.3",
-		"vscode-extension-tester": "^3.2.6",
+		"vscode-extension-tester": "^4.0.2",
 		"vscode-extension-tester-native": "^3.0.2",
 		"vscode-test": "^1.5.1",
 		"vscode-uitests-tooling": "^2.0.1"


### PR DESCRIPTION
required to fix master after vs code regression for url availability affecting vscode-extension-tester https://github.com/redhat-developer/vscode-extension-tester/issues/257