### PR TITLE
FUSETOOLS2-1043 - update compilation classpath when ready

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import * as kubectl from './kubectl';
 import * as kamel from './kamel';
 import * as kubectlutils from './kubectlutils';
 import * as config from './config';
-import { downloadJavaDependencies, updateReferenceLibraries } from './JavaDependenciesManager';
+import { initializeJavaDependenciesManager } from './JavaDependenciesManager';
 import { CamelKTaskCompletionItemProvider } from './task/CamelKTaskCompletionItemProvider';
 import { CamelKTaskProvider } from './task/CamelKTaskDefinition';
 import { ChildProcess } from 'child_process';
@@ -177,15 +177,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('camelk.integrations.selectFirstNode', () => { selectFirstItemInTree();});
 	});
 
-	let destination = downloadJavaDependencies(context);
-	
-	vscode.window.onDidChangeActiveTextEditor((editor) => {
-		updateReferenceLibraries(editor, destination);
-	});
-	
-	if (vscode.window.activeTextEditor) {
-		updateReferenceLibraries(vscode.window.activeTextEditor, destination);
-	}
+	initializeJavaDependenciesManager(context);
 	
 	vscode.workspace.onDidChangeConfiguration(async (event) => {
 		await handleChangeRuntimeConfiguration();


### PR DESCRIPTION
https://drive.google.com/file/d/1ukRoit7eG1DqxE4NiJO2DC4js8XTRBRa/view?usp=sharing

it allows to have compilation classpath well detected when isntalling VS
Code Camel K extension and that the Java Camel K file is already open.

as it is a complicated use case to test (need to uninstall extension
under test, clean settings folder or restart vs code and then reinstall
it), I do not know how it can be easily automated at the level we have
setup the test infrastructure.

for the future, might be nice to have a feedback to the user on the
progress of the downloads so that he/she knows that the "current
compilation" error should vanish soon. But my last attempt to have
feedback progress from Maven launched through node was a failure.

