### PR TITLE
Update badge for chat that ha moved from Gitter to Zulip

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.com/camel-tooling/vscode-camelk.svg?branch=master)](https://travis-ci.com/camel-tooling/vscode-camelk)
 [![CircleCI](https://circleci.com/gh/camel-tooling/vscode-camelk.svg?style=shield)](https://circleci.com/gh/camel-tooling/vscode-camelk)
 [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)]()
-[![Gitter](https://img.shields.io/gitter/room/camel-tooling/Lobby.js.svg)](https://gitter.im/camel-tooling/Lobby)
+[![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://camel.zulipchat.com/#narrow/stream/258729-camel-tooling)
 
 # Visual Studio extension to support Apache Camel K
 


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>