### PR TITLE
FUSETOOLS2-1036 - provide more precise telemetry for Start integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
   - It supports modeline dependencies notation from local build. See [apache/camel-k#2213](https://github.com/apache/camel-k/issues/2213)
   - A single classpath is provided. It means that refresh command needs to be called when switching between Integration file written in Java that does not have the same dependencies.
   - There is no progress indicator. Please be patient. The first time may take several minutes on a slow network.
+- Provide telemetry information when using `Start Apache Camel K integration` command about language of the file deployed and the kind of deployment used (basic, dev, ...)
 
 ## 0.0.23
 

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -6,3 +6,6 @@
 * when a command from this extension is used, the command id is provided
 * when `Create a new Apache Camel K Integration file` command contributed by extension is executed
     * with the chosen language
+* when `Start Apache Camel K integration` command contributed by extension is executed
+    * with the language of the file deployed
+    * with the kind (basic, dev, ...)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ const COMMAND_ID_START_LOG = 'camelk.integrations.log';
 const COMMAND_ID_REFRESH = 'camelk.integrations.refresh';
 
 const COMMAND_ID_REMOVE = 'camelk.integrations.remove';
-const COMMAND_ID_START_INTEGRATION = 'camelk.startintegration';
+export const COMMAND_ID_START_INTEGRATION = 'camelk.startintegration';
 const COMMAND_ID_OPEN_OPERATOR_LOG = 'camelk.integrations.openOperatorLog';
 export async function activate(context: vscode.ExtensionContext) {
 	stashedContext = context;
@@ -156,7 +156,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(vscode.commands.registerCommand(COMMAND_ID_START_INTEGRATION,
 			async (...args:any[]) => {
 				await runTheFile(args);
-				telemetry.sendCommandTracking(COMMAND_ID_START_INTEGRATION);
 			}));
 	
 		// add commands to create config-map and secret objects from .properties files


### PR DESCRIPTION
command

- language of file by providing the extension; prefer to provide the extension to avoid to handle all potential cases of extension yaml/yml/YAML and surely other ways to write that I miss)
- main option of the command

it will give this kind of reports:

![Screenshot from 2021-04-28 20-43-39](https://user-images.githubusercontent.com/1105127/116456342-751c9180-a862-11eb-9381-af3934b2ddb4.png)
![Screenshot from 2021-04-28 20-43-18](https://user-images.githubusercontent.com/1105127/116456345-75b52800-a862-11eb-9956-cabfb01ef5a0.png)
