### PR TITLE
FUSETOOLS2-1093 - provide more information in case of test failure and await complete removal in teardown

### DIFF
--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -58,7 +58,7 @@ suite('Check can deploy default examples', () => {
 		telemetrySpy = sinon.spy(await getTelemetryServiceInstance(), 'send');
 	});
 
-	teardown(() => {
+	teardown(async () => {
 		showQuickpickStub.restore();
 		showInputBoxStub.restore();
 		showWorkspaceFolderPickStub.restore();
@@ -67,12 +67,12 @@ suite('Check can deploy default examples', () => {
 		}
 		const deployedTreeNode = getCamelKIntegrationsProvider().getTreeNodes()[0];
 		if(deployedTreeNode) {
-			vscode.commands.executeCommand('camelk.integrations.remove', deployedTreeNode);
-			waitUntil(() => {
+			await vscode.commands.executeCommand('camelk.integrations.remove', deployedTreeNode);
+			await waitUntil(() => {
 				return getCamelKIntegrationsProvider().getTreeNodes().length === 0;
 			}, UNDEPLOY_TIMEOUT);
 		}
-		config.addNamespaceToConfig(undefined);
+		await config.addNamespaceToConfig(undefined);
 		telemetrySpy.restore();
 	});
 	

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -194,7 +194,7 @@ async function createFile(showQuickpickStub: sinon.SinonStub<any[], any>,
 }
 
 function checkTelemetry(telemetrySpy: sinon.SinonSpy<any[], any>, languageExtension: string) {
-	expect(telemetrySpy.calledOnce, `telemetry expected to be called once but was called ${telemetrySpy.callCount}.\n${getTelemetryCallsContent(telemetrySpy)}`).true;
+	expect(telemetrySpy.calledOnce, `telemetry expected to be called once but was called ${telemetrySpy.callCount} time(s).\n${getTelemetryCallsContent(telemetrySpy)}`).true;
 	const actualEvent: TelemetryEvent = telemetrySpy.getCall(0).args[0];
 	expect(actualEvent.name).to.be.equal('command');
 	expect(actualEvent.properties.identifier).to.be.equal(extension.COMMAND_ID_START_INTEGRATION);

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -98,7 +98,7 @@ suite('Check can deploy default examples', () => {
 		showQuickpickStub.onSecondCall().returns(IntegrationUtils.vscodeTasksIntegration);
 		showQuickpickStub.onThirdCall().returns(CamelKTaskDefinition.NAME_OF_PROVIDED_TASK_TO_DEPLOY_IN_DEV_MODE_FROM_ACTIVE_EDITOR);
 		
-		await vscode.commands.executeCommand('camelk.startintegration');
+	 	await vscode.commands.executeCommand('camelk.startintegration');
 
 		await checkIntegrationDeployed();
 		await checkIntegrationRunning();
@@ -194,9 +194,21 @@ async function createFile(showQuickpickStub: sinon.SinonStub<any[], any>,
 }
 
 function checkTelemetry(telemetrySpy: sinon.SinonSpy<any[], any>, languageExtension: string) {
-	expect(telemetrySpy.calledOnce, `telemetry expected to be called once but was called ${telemetrySpy.callCount}`).true;
+	expect(telemetrySpy.calledOnce, `telemetry expected to be called once but was called ${telemetrySpy.callCount}.\n${getTelemetryCallsContent(telemetrySpy)}`).true;
 	const actualEvent: TelemetryEvent = telemetrySpy.getCall(0).args[0];
 	expect(actualEvent.name).to.be.equal('command');
 	expect(actualEvent.properties.identifier).to.be.equal(extension.COMMAND_ID_START_INTEGRATION);
 	expect(actualEvent.properties.language).to.be.equal(languageExtension);
+}
+function getTelemetryCallsContent(telemetrySpy: sinon.SinonSpy<any[], any>): string {
+	let res = '';
+	telemetrySpy.getCalls().forEach(call => {
+		call.args.forEach(telemetryEvent => {
+			res += telemetryEvent.name + ';'
+				+ 'identifier: '+ telemetryEvent.properties.identifier + ';'
+				+ 'language: '+ telemetryEvent.properties.language + ';'
+				+ 'kind: ' + telemetryEvent.properties.kind  + '\n';
+		});
+	});
+	return res;
 }


### PR DESCRIPTION
improved error message give something like:
```
 1) Check can deploy default examples
       Check basic deployments for each languages
         Check can deploy Groovy example:

      AssertionError: telemetry expected to be called once but was called 2. command;identifier: camelk.integrations.remove;language: undefined;kindundefined
command;identifier: camelk.startintegration;language: groovy;kindBasic - Apache Camel K Integration (no ConfigMap or Secret)
: expected false to be true
      + expected - actual
```

instead of:
```
  1) Check can deploy default examples
       Check basic deployments for each languages
         Check can deploy Yaml example:

      telemetry expected to be called once but was called 2
      + expected - actual
```
