### PR TITLE
FUSETOOLS2-1094 - provide more precise error message in test failure for

### DIFF
--- a/src/test/suite/completion.util.ts
+++ b/src/test/suite/completion.util.ts
@@ -50,6 +50,6 @@ export async function checkExpectedCompletion(docUri: vscode.Uri, position: vsco
 				errorMessage += completion.label + '\n';
 			});
 		}
-		throw new Error(`${err}\nCannot found expected completion "${expectedCompletion.label}" in the list of completions:\n${errorMessage}`);
+		throw new Error(`${err}\nCannot find expected completion "${expectedCompletion.label}" in the list of completions:\n${errorMessage}`);
 	}
 }


### PR DESCRIPTION
expected completion not found

the error will be something like:

```
  7) Should do completion in yaml Camel K files without file name pattern
       Completes for first level:
     Error: Error: Timed out after waiting for 10000 ms
Cannot found expected completion "test" in the list of completions:
error-handler
from
my-added-property-for-the-demo
on-exception
rest
route
```

instead of somethign like:
```
  1) Should do completion in Camel K standalone files
       Completes additional dependencies:
     Error: Timed out after waiting for 10000 ms
  	at /home/circleci/project/node_modules/async-wait-until/dist/index.js:1:1034
 ```