### PR TITLE
Fusetools2 950 contexttual menu start java debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.25
 
-- Provide specific `camel-k-debug`  VS Code tasks
+- Debugging:
+  - Provide right-click menu in Integration view to attach a Java debugger. It requires to be launched on localhost.
+  - Provide specific `camel-k-debug`  VS Code tasks
 
 ## 0.0.24
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,9 @@ Be aware of the following limitations:
   - A single classpath is provided. It means that refresh command needs to be called when switching between Integration file written in Java that does not have the same dependencies.
   - There is no progress indicator. Please be patient. The first time may take several minutes on a slow network.
   
-To benefit from Java debug on standalone files, [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) needs to be installed. To leverage it, you need to start an integration, then launch a `camel-k-debug` VS Code tasks and then to launch a `java` attach in debug VS Code tasks.
+To benefit from Java debug on standalone files, [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) needs to be installed. To leverage it, you need to start an integration, then there are 2 solutions:
+- Right-click on integration in Integrations view, then choose `Start Java debugger on Camel K integration`.
+- Launch a `camel-k-debug` VS Code tasks and then to launch a `java` attach in debug VS Code tasks.
 
 ## Apache Camel K Extension Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -298,6 +298,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/detect-port": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.0.tgz",
+			"integrity": "sha512-NnDUDk1Ry5cHljTFetg0BNT79FaJSddTh9RsGOS2v/97DwOUJ+hBkgxtQHF6T8IarZD4i+bFEL787Nz+xpodfA=="
+		},
 		"@types/download": {
 			"version": "6.2.4",
 			"resolved": "https://registry.npmjs.org/@types/download/-/download-6.2.4.tgz",
@@ -459,6 +464,11 @@
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
 			"dev": true
+		},
+		"address": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
 		},
 		"agent-base": {
 			"version": "6.0.2",
@@ -1689,6 +1699,30 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"dev": true
+		},
+		"detect-port": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+			"integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+			"requires": {
+				"address": "^1.0.1",
+				"debug": "^2.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
 		},
 		"diff": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -364,11 +364,13 @@
 	],
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.0.18",
+		"@types/detect-port": "^1.3.0",
 		"@types/request-promise": "^4.1.47",
 		"@types/shelljs": "^0.8.8",
 		"@types/tmp": "^0.2.0",
 		"child_process": "^1.0.2",
 		"cross-fetch": "^3.1.4",
+		"detect-port": "^1.3.0",
 		"download": "^8.0.0",
 		"jsonc-parser": "^3.0.0",
 		"maven": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -156,6 +156,10 @@
 				"command": "camelk.classpath.refresh",
 				"title": "Refresh local Java classpath for Camel K standalone file based on current editor. Available with kamel 1.4+.",
 				"enablement": "editorIsOpen && editorLangId == java"
+			},
+			{
+				"command": "camelk.integrations.debug.java",
+				"title": "Start Java debugger on Camel K integration"
 			}
 		],
 		"menus": {
@@ -207,6 +211,11 @@
 				{
 					"command": "camelk.integrations.log",
 					"group": "2_loggroup@1",
+					"when": "view == camelk.integrations"
+				},
+				{
+					"command": "camelk.integrations.debug.java",
+					"group": "3_debuggroup@2",
 					"when": "view == camelk.integrations"
 				}
 			]

--- a/src/commands/StartJavaDebuggerCommand.ts
+++ b/src/commands/StartJavaDebuggerCommand.ts
@@ -35,11 +35,13 @@ export async function start(integrationItem: TreeNode): Promise<void> {
 	const childProcess = await kamelExecutor.invokeArgs(kamelArgs);
 	let debuggerLaunched = false;
 	let isListeningFromTransportMessageSent = false;
+	let isForwardingFrommessageSent = false; 
 	childProcess.stdout?.on('data', function (data) {
 		const messageData: string = `${data}`;
 		console.log(messageData);
 		isListeningFromTransportMessageSent ||= messageData.includes('Listening for transport dt_socket at address:');
-		if (!debuggerLaunched && isListeningFromTransportMessageSent && messageData.includes('Forwarding from')) {
+		isForwardingFrommessageSent ||= messageData.includes('Forwarding from');
+		if (!debuggerLaunched && isListeningFromTransportMessageSent && isForwardingFrommessageSent) {
 			const workspaceFolderList = vscode.workspace.workspaceFolders;
 			if (workspaceFolderList) {
 				const debugConfigurationName = `Attach Java debugger to Camel K integration ${integrationName} on port ${port}`;

--- a/src/commands/StartJavaDebuggerCommand.ts
+++ b/src/commands/StartJavaDebuggerCommand.ts
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as kamel from '../kamel';
+import { TreeNode } from "../CamelKNodeProvider";
+
+export async function start(integrationItem: TreeNode): Promise<void> {
+	const kamelExecutor: kamel.Kamel = kamel.create();
+	let kamelArgs: string[] = [];
+	kamelArgs.push('debug');
+	const integrationName = integrationItem.label as string;
+	kamelArgs.push(integrationName);
+	//TODO: improve by searching for a free port
+	const childProcess = await kamelExecutor.invokeArgs(kamelArgs);
+	let debuggerLaunched = false;
+	childProcess.stdout?.on('data', function (data) {
+		const messageData: string = `${data}`;
+		if (!debuggerLaunched && messageData.includes('Listening for transport dt_socket at address:')) {
+			const workspaceFolderList = vscode.workspace.workspaceFolders;
+			if (workspaceFolderList) {
+				const debugConfiguration: vscode.DebugConfiguration = {
+					name: `Attach Java debugger to Camel K integration ${integrationName}`,
+					type: 'java',
+					request: 'attach',
+					// TODO: how to determine host more precisely?
+					hostName: 'localhost',
+					port: 5005
+				};
+				debuggerLaunched = true;
+				vscode.debug.startDebugging(workspaceFolderList[0], debugConfiguration);
+			}
+		}
+	});
+	//TODO: delete child process when disconnecting? When undeploying? How?
+}

--- a/src/commands/StartJavaDebuggerCommand.ts
+++ b/src/commands/StartJavaDebuggerCommand.ts
@@ -38,7 +38,6 @@ export async function start(integrationItem: TreeNode): Promise<void> {
 	let isForwardingFrommessageSent = false; 
 	childProcess.stdout?.on('data', function (data) {
 		const messageData: string = `${data}`;
-		console.log(messageData);
 		isListeningFromTransportMessageSent ||= messageData.includes('Listening for transport dt_socket at address:');
 		isForwardingFrommessageSent ||= messageData.includes('Forwarding from');
 		if (!debuggerLaunched && isListeningFromTransportMessageSent && isForwardingFrommessageSent) {
@@ -54,7 +53,7 @@ export async function start(integrationItem: TreeNode): Promise<void> {
 					port: +port
 				};
 				debuggerLaunched = true;
-				vscode.debug.registerDebugAdapterTrackerFactory('*', {
+				const disposable = vscode.debug.registerDebugAdapterTrackerFactory('*', {
 					createDebugAdapterTracker(session: vscode.DebugSession) {
 						return {
 							onWillStopSession:() => {
@@ -65,6 +64,7 @@ export async function start(integrationItem: TreeNode): Promise<void> {
 							onExit: (code, signal) => {
 								if(debugConfigurationName === session.name) {
 									childProcess.kill(code);
+									disposable.dispose();
 								}
 							}
 						};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import * as kubectl from './kubectl';
 import * as kamel from './kamel';
 import * as kubectlutils from './kubectlutils';
 import * as config from './config';
+import * as StartJavaDebuggerCommand from './commands/StartJavaDebuggerCommand'
 import { downloadSpecificCamelKJavaDependencies, initializeJavaDependenciesManager } from './JavaDependenciesManager';
 import { CamelKTaskCompletionItemProvider } from './task/CamelKTaskCompletionItemProvider';
 import { CamelKDebugTaskProvider } from './task/CamelKDebugTaskDefinition';
@@ -63,6 +64,7 @@ const COMMAND_ID_REFRESH = 'camelk.integrations.refresh';
 const COMMAND_ID_REMOVE = 'camelk.integrations.remove';
 export const COMMAND_ID_START_INTEGRATION = 'camelk.startintegration';
 const COMMAND_ID_OPEN_OPERATOR_LOG = 'camelk.integrations.openOperatorLog';
+export const COMMAND_ID_START_JAVA_DEBUG = 'camelk.integrations.debug.java';
 export async function activate(context: vscode.ExtensionContext) {
 	stashedContext = context;
 	camelKIntegrationsProvider = new CamelKNodeProvider(context);
@@ -178,6 +180,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('camelk.integrations.createNewIntegrationFile', async (...args:any[]) => { await NewIntegrationFileCommand.create(args);});
 		vscode.commands.registerCommand('camelk.integrations.selectFirstNode', () => { selectFirstItemInTree();});
 		vscode.commands.registerCommand('camelk.classpath.refresh', async (uri:vscode.Uri) => { await downloadSpecificCamelKJavaDependencies(context, uri, mainOutputChannel)});
+		vscode.commands.registerCommand(COMMAND_ID_START_JAVA_DEBUG, async (integrationItem: TreeNode) => {
+			await StartJavaDebuggerCommand.start(integrationItem);
+			telemetry.sendCommandTracking(COMMAND_ID_START_JAVA_DEBUG);
+		});
 	});
 
 	initializeJavaDependenciesManager(context);

--- a/src/test/suite/DebugIntegration.test.ts
+++ b/src/test/suite/DebugIntegration.test.ts
@@ -64,7 +64,7 @@ suite('Check can debug default Java example', () => {
 		showWorkspaceFolderPickStub.restore();
 		cleanFile(createdFile);
 		cleanFile(secondCreatedFile);
-		await cleanDeployedIntegration();
+		await cleanDeployedIntegration(telemetrySpy);
 		await config.addNamespaceToConfig(undefined);
 		telemetrySpy.restore();
 		if(debugConfigurationTaskExecution) {

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -65,7 +65,7 @@ suite('Check can deploy default examples', () => {
 		if (createdFile && fs.existsSync(createdFile.fsPath)) {
 			fs.unlinkSync(createdFile.fsPath);
 		}
-		await cleanDeployedIntegration();
+		await cleanDeployedIntegration(telemetrySpy);
 		await config.addNamespaceToConfig(undefined);
 		telemetrySpy.restore();
 	});

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -76,7 +76,7 @@ suite('Check can deploy default examples', () => {
 				skipOnJenkins(testInProgress);
 				createdFile = await createFile(showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, `TestBasic${language}Deploy`, language);
 				
-				await startIntegrationWithBasicCheck(showQuickpickStub, telemetrySpy);
+				await startIntegrationWithBasicCheck(showQuickpickStub, telemetrySpy, 0);
 				const extensionFile = LANGUAGES_WITH_FILENAME_EXTENSIONS.get(language);
 				checkTelemetry(telemetrySpy, extensionFile ? extensionFile : "");
 			}).timeout(TOTAL_TIMEOUT);
@@ -94,8 +94,8 @@ suite('Check can deploy default examples', () => {
 		
 	 	await vscode.commands.executeCommand('camelk.startintegration');
 
-		await checkIntegrationDeployed();
-		await checkIntegrationRunning();
+		await checkIntegrationDeployed(1);
+		await checkIntegrationRunning(0);
 	}).timeout(TOTAL_TIMEOUT);
 	
 	const testSpecificNamespace = test('Check can deploy on specific namespace', async () => {
@@ -104,7 +104,7 @@ suite('Check can deploy default examples', () => {
 		createdFile = await createFile(showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, 'TestDeployInSpecificNamespace', 'Java');
 		await config.addNamespaceToConfig(EXTRA_NAMESPACE_FOR_TEST);
 
-		await startIntegrationWithBasicCheck(showQuickpickStub, telemetrySpy);
+		await startIntegrationWithBasicCheck(showQuickpickStub, telemetrySpy, 0);
 		await checkIntegrationsInDifferentNamespaces(EXTRA_NAMESPACE_FOR_TEST);
 		
 		shelljs.exec(`${await kubectl.create().getPath()} delete namespace ${EXTRA_NAMESPACE_FOR_TEST}`);

--- a/src/test/suite/Utils/DeployTestUtil.ts
+++ b/src/test/suite/Utils/DeployTestUtil.ts
@@ -28,15 +28,16 @@ import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
 import { TreeNode } from '../../../CamelKNodeProvider';
 import { UNDEPLOY_TIMEOUT, PROVIDER_POPULATED_TIMEOUT, RUNNING_TIMEOUT, DEPLOYED_TIMEOUT, EDITOR_OPENED_TIMEOUT } from '../StartIntegration.test';
 
-export async function cleanDeployedIntegration() {
+export async function cleanDeployedIntegration(telemetrySpy: sinon.SinonSpy) {
 	let deployedTreeNodes: TreeNode[] | undefined = await retrieveDeployedTreeNodes();
 	if (deployedTreeNodes) {
+		telemetrySpy.resetHistory();
 		deployedTreeNodes.forEach(deployedTreeNode => {
 			vscode.commands.executeCommand('camelk.integrations.remove', deployedTreeNode);
 		});
 		try {
 			await waitUntil(() => {
-				return getCamelKIntegrationsProvider().getTreeNodes().length === 0;
+				return getCamelKIntegrationsProvider().getTreeNodes().length === 0 && telemetrySpy.callCount === deployedTreeNodes?.length;
 			}, UNDEPLOY_TIMEOUT);
 		} catch (error) {
 			console.log('Error while trying to remove deployed integrations, it remains:');

--- a/src/test/suite/kubectlwatcher.test.ts
+++ b/src/test/suite/kubectlwatcher.test.ts
@@ -33,9 +33,10 @@ suite("Kubectl integration watcher", function() {
 	this.beforeAll(async () => {
 		this.timeout(60000);
 		await Utils.ensureExtensionActivated();
+		await sleep(extension.DELAY_RETRY_KUBECTL_CONNECTION);
 	});
 
-	this.beforeEach(() => {
+	this.beforeEach(async () => {
 		sandbox = sinon.createSandbox();
 		refreshStub = sandbox.stub(Utils.getCamelKIntegrationsProvider(), 'refresh');
 		messageStub = sandbox.stub(Utils.getCamelKMainOutputChannel(), 'append');

--- a/src/test/suite/kubectlwatcher.test.ts
+++ b/src/test/suite/kubectlwatcher.test.ts
@@ -36,7 +36,7 @@ suite("Kubectl integration watcher", function() {
 		await sleep(extension.DELAY_RETRY_KUBECTL_CONNECTION);
 	});
 
-	this.beforeEach(async () => {
+	this.beforeEach(() => {
 		sandbox = sinon.createSandbox();
 		refreshStub = sandbox.stub(Utils.getCamelKIntegrationsProvider(), 'refresh');
 		messageStub = sandbox.stub(Utils.getCamelKMainOutputChannel(), 'append');


### PR DESCRIPTION
~requires https://github.com/camel-tooling/vscode-camelk/pull/752/~

video for simple case: https://youtu.be/TQasRr1PiYw

scope and direct limitations:
- basic use case handled fo rlocalhost only (for remote https://issues.redhat.com/browse/FUSETOOLS2-1122 )
- multiple debug session launched in parallel handled
- contextual menu is always available and enable on right-click on Integrations (https://issues.redhat.com/browse/FUSETOOLS2-1126 )
- command is visible in command palette https://issues.redhat.com/browse/FUSETOOLS2-1127