### PR TITLE
Fusetools2 1122 for remote instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.25
 
 - Debugging:
-  - Provide right-click menu in Integration view to attach a Java debugger. It requires to be launched on localhost.
+  - Provide right-click menu in Integration view to attach a Java debugger
   - Provide specific `camel-k-debug`  VS Code tasks
 
 ## 0.0.24

--- a/src/commands/StartJavaDebuggerCommand.ts
+++ b/src/commands/StartJavaDebuggerCommand.ts
@@ -48,7 +48,6 @@ export async function start(integrationItem: TreeNode): Promise<void> {
 					name: debugConfigurationName,
 					type: 'java',
 					request: 'attach',
-					// TODO: To improve to support remote debug. How to determine host more precisely?
 					hostName: 'localhost',
 					port: +port
 				};


### PR DESCRIPTION
requires https://github.com/camel-tooling/vscode-camelk/pull/759

https://youtu.be/gQYYuVfeUjw

in fact, the `kamel debug` is a proxy to the remote instance. So from VS
Code, it is always connecting to the localhost and then `kamel debug` is
redirecting at the correct place
