### PR TITLE
FUSETOOLS2-1137 - ensure retrieving updated list of TreeNode

### DIFF
--- a/src/test/suite/DebugIntegration.test.ts
+++ b/src/test/suite/DebugIntegration.test.ts
@@ -25,7 +25,7 @@ import * as Utils from "./Utils";
 import * as shelljs from 'shelljs';
 import { LANGUAGES_WITH_FILENAME_EXTENSIONS } from '../../commands/NewIntegrationFileCommand';
 import { getTelemetryServiceInstance } from '../../Telemetry';
-import { cleanDeployedIntegration, createFile, startIntegrationWithBasicCheck, checkTelemetry} from './Utils/DeployTestUtil';
+import { cleanDeployedIntegration, createFile, startIntegrationWithBasicCheck, checkTelemetry, retrieveDeployedTreeNodes} from './Utils/DeployTestUtil';
 import { CamelKDebugTaskProvider } from '../../task/CamelKDebugTaskDefinition';
 import { waitUntil } from 'async-wait-until';
 import { fail } from 'assert';
@@ -88,7 +88,7 @@ suite('Check can debug default Java example', () => {
 		Utils.skipOnJenkins(testUsingContextualMenu);
 		createdFile = await createAndDeployIntegration(createdFile, showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, telemetrySpy, 'ContextualMenu', 0);
 		
-		await vscode.commands.executeCommand(extension.COMMAND_ID_START_JAVA_DEBUG, Utils.getCamelKIntegrationsProvider().getTreeNodes()[0]);
+		await vscode.commands.executeCommand(extension.COMMAND_ID_START_JAVA_DEBUG, (await retrieveDeployedTreeNodes())[0]);
 		
 		await checkActiveDebugSessionAutomaticallyCreated('test-java-debug-contextual-menu', 5005);
 	}).timeout(TOTAL_TIMEOUT);
@@ -99,14 +99,14 @@ suite('Check can debug default Java example', () => {
 		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 		secondCreatedFile = await createAndDeployIntegration(secondCreatedFile, showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, telemetrySpy, 'Second', 1);
 		
-		await vscode.commands.executeCommand(extension.COMMAND_ID_START_JAVA_DEBUG, Utils.getCamelKIntegrationsProvider().getTreeNodes()[0]);
+		await vscode.commands.executeCommand(extension.COMMAND_ID_START_JAVA_DEBUG, (await retrieveDeployedTreeNodes())[0]);
 		await checkActiveDebugSessionAutomaticallyCreated('test-java-debug-first', 5005);
 		
 		let isSessionStarted = false;
 		vscode.debug.onDidStartDebugSession(debugSession => {
 			isSessionStarted ||= debugSession.name === `Attach Java debugger to Camel K integration test-java-debug-second on port 5006`;
-		});	
-		await vscode.commands.executeCommand(extension.COMMAND_ID_START_JAVA_DEBUG, Utils.getCamelKIntegrationsProvider().getTreeNodes()[1]);
+		});
+		await vscode.commands.executeCommand(extension.COMMAND_ID_START_JAVA_DEBUG, (await retrieveDeployedTreeNodes(2))[1]);
 		try {
 			await waitUntil(() => {
 				return isSessionStarted;

--- a/src/test/suite/Utils/DeployTestUtil.ts
+++ b/src/test/suite/Utils/DeployTestUtil.ts
@@ -49,15 +49,15 @@ export async function cleanDeployedIntegration(telemetrySpy: sinon.SinonSpy) {
 	}
 }
 
-async function retrieveDeployedTreeNodes(): Promise<TreeNode[]> {
+export async function retrieveDeployedTreeNodes(minimalExpectedTreeNode =1): Promise<TreeNode[]> {
 	let deployedTreeNodes: TreeNode[] = [];
 	try {
 		await waitUntil(() => {
 			deployedTreeNodes = getCamelKIntegrationsProvider().getTreeNodes();
-			return deployedTreeNodes.length !== 0;
+			return deployedTreeNodes.length >= minimalExpectedTreeNode;
 		}, PROVIDER_POPULATED_TIMEOUT);
 	} catch (err) {
-		console.log('No Integration found in Camel K Integration provider of the view.');
+		console.log(`Less than ${minimalExpectedTreeNode} Integration found in Camel K Integration provider of the view.`);
 	}
 	return deployedTreeNodes;
 }


### PR DESCRIPTION
a more precise conditional wait must be used due to automatic refresh
which is clearing the list of TreeNode and repopulating one by one
after.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>