### PR TITLE
Remove redundant use of `await` on a return value

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -160,7 +160,7 @@ export function getKamelRuntimeVersionConfig(): string | undefined {
 
 export async function setKamelRuntimeVersionConfig(value : string) : Promise<void> {
 	const configuration = vscode.workspace.getConfiguration();
-	return await configuration.update(RUNTIME_VERSION_KEY, stripLeadingV(value), vscode.ConfigurationTarget.Global);
+	return configuration.update(RUNTIME_VERSION_KEY, stripLeadingV(value), vscode.ConfigurationTarget.Global);
 }
 
 export function getKamelAutoupgradeConfig() : boolean {
@@ -171,5 +171,5 @@ export function getKamelAutoupgradeConfig() : boolean {
 // for testing purposes 
 export async function setKamelAutoupgradeConfig(value : boolean) : Promise<void> {
 	const configuration = vscode.workspace.getConfiguration();
-	return await configuration.update(AUTOUPGRADE_KEY, value, vscode.ConfigurationTarget.Global);
+	return configuration.update(AUTOUPGRADE_KEY, value, vscode.ConfigurationTarget.Global);
 }

--- a/src/kamel.ts
+++ b/src/kamel.ts
@@ -41,7 +41,7 @@ class KamelImpl implements Kamel {
 	}
 
 	async getPath(): Promise<string> {
-		return await baseKamelPath();
+		return baseKamelPath();
 	}
 
 	async invoke(command: string): Promise<string> {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -39,7 +39,7 @@ class KubectlImpl implements Kubectl {
 	}
 
 	async getPath(): Promise<string> {
-		return await baseKubectlPath();
+		return baseKubectlPath();
 	}
 
 	invokeArgs(args: string[], folderName?: string): Promise<child_process.ChildProcess> {

--- a/src/kubectlutils.ts
+++ b/src/kubectlutils.ts
@@ -80,27 +80,27 @@ export function parseShellResult(output: string) : string[] {
 export async function getConfigMaps(): Promise<string[]> {
 	const namespace: string | undefined = config.getNamespaceconfig();
 	if (namespace) {
-		return await getNamedListFromKubernetesThenParseList('configmap', `--namespace=${namespace}`);
+		return getNamedListFromKubernetesThenParseList('configmap', `--namespace=${namespace}`);
 	} else {
-		return await getNamedListFromKubernetesThenParseList('configmap');
+		return getNamedListFromKubernetesThenParseList('configmap');
 	}
 }
 
 export async function getSecrets(): Promise<string[]> {
 	const namespace: string | undefined = config.getNamespaceconfig();
 	if (namespace) {
-		return await getNamedListFromKubernetesThenParseList('secret', `--namespace=${namespace}`);
+		return getNamedListFromKubernetesThenParseList('secret', `--namespace=${namespace}`);
 	} else {
-		return await getNamedListFromKubernetesThenParseList('secret');
+		return getNamedListFromKubernetesThenParseList('secret');
 	}
 }
 
 export async function getIntegrations(): Promise<string> {
 	const namespace: string | undefined = config.getNamespaceconfig();
 	if (namespace) {
-		return await getNamedListFromKubernetes('integration', `--namespace=${namespace}`);
+		return getNamedListFromKubernetes('integration', `--namespace=${namespace}`);
 	} else {
-		return await getNamedListFromKubernetes('integration');
+		return getNamedListFromKubernetes('integration');
 	}
 }
 

--- a/src/task/CamelKDebugTaskDefinition.ts
+++ b/src/task/CamelKDebugTaskDefinition.ts
@@ -38,7 +38,7 @@ export class CamelKDebugTaskProvider implements vscode.TaskProvider {
 
 	public async resolveTask(_task: vscode.Task): Promise<vscode.Task | undefined> {
 		const definition: CamelKDebugTaskDefinition = <any>_task.definition;
-		return await this.getDebugTask(definition);
+		return this.getDebugTask(definition);
 	}
 
 	private async getTasks(): Promise<vscode.Task[]> {

--- a/src/task/CamelKRunTaskDefinition.ts
+++ b/src/task/CamelKRunTaskDefinition.ts
@@ -50,7 +50,7 @@ export class CamelKRunTaskProvider implements vscode.TaskProvider {
 
 	public async resolveTask(_task: vscode.Task): Promise<vscode.Task | undefined> {
 		const definition: CamelKRunTaskDefinition = <any>_task.definition;
-		return await this.getRunTask(definition);
+		return this.getRunTask(definition);
 	}
 
 	private async getTasks(): Promise<vscode.Task[]> {


### PR DESCRIPTION
as reported as code smell by Sonar
https://sonarcloud.io/project/issues?id=vscode-camelk&resolved=false&rules=typescript%3AS4326&types=CODE_SMELL

Signed-off-by: Aurélien Pupier <apupier@redhat.com>