### PR TITLE
#769: Use an enum to detected the OS platform

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -23,6 +23,12 @@ const WINDOWS: string = 'win32';
 const MACOS : string = 'darwin';
 const LINUX : string = 'linux';
 
+export enum Platform {
+    WINDOWS,
+    MACOS,
+    LINUX
+}
+
 export interface FindBinaryResult {
 	err: number | null;
 	output: string;
@@ -51,10 +57,10 @@ export function isUnix(): boolean {
     return (process.platform === LINUX);
 }
 
-export function getPlatform() : string | undefined {
-    if (isWindows()) { return WINDOWS; }
-    if (isMacOS()) { return MACOS; }
-    if (isUnix()) { return LINUX; }
+export function getPlatform() : Platform | undefined {
+    if (isWindows()) { return Platform.WINDOWS; }
+    if (isMacOS()) { return Platform.MACOS; }
+    if (isUnix()) { return Platform.LINUX; }
     return undefined;
 }
 

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -18,6 +18,7 @@
 
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
+import { Platform } from '../../shell';
 import * as versionUtils from '../../versionUtils';
 
 chai.use(sinonChai);
@@ -26,52 +27,60 @@ const should = chai.should();
 suite("ensure version url methods are functioning as expected", () => {
 
 	test("validate url for existing 1.0.0 version", async () => {
-		await validateVersion('1.0.0', 'linux', 'https://github.com/apache/camel-k/releases/download/1.0.0/camel-k-client-1.0.0-linux-64bit.tar.gz');
+		await validateVersion('1.0.0', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/1.0.0/camel-k-client-1.0.0-linux-64bit.tar.gz');
 	});
 
 	test("validate url for existing 1.0.1 version", async () => {
-		await validateVersion('1.0.1', 'linux', 'https://github.com/apache/camel-k/releases/download/1.0.1/camel-k-client-1.0.1-linux-64bit.tar.gz');
+		await validateVersion('1.0.1', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/1.0.1/camel-k-client-1.0.1-linux-64bit.tar.gz');
 	});
 
 	test("validate url for existing 1.1.0 version", async () => {
-		await validateVersion('1.1.0', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.1.0/camel-k-client-1.1.0-linux-64bit.tar.gz');
+		await validateVersion('1.1.0', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.1.0/camel-k-client-1.1.0-linux-64bit.tar.gz');
 	});
-	
+
 	test("validate url for existing 1.1.1 version", async () => {
-		await validateVersion('1.1.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.1.1/camel-k-client-1.1.1-linux-64bit.tar.gz');
+		await validateVersion('1.1.1', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.1.1/camel-k-client-1.1.1-linux-64bit.tar.gz');
 	});
-	
+
 	test("validate url for existing 1.2.1 version", async () => {
-		await validateVersion('1.2.1', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.2.1/camel-k-client-1.2.1-linux-64bit.tar.gz');
+		await validateVersion('1.2.1', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.2.1/camel-k-client-1.2.1-linux-64bit.tar.gz');
 	});
-	
+
 	test("validate url for existing 1.3.2 version", async () => {
-		await validateVersion('1.3.2', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.3.2/camel-k-client-1.3.2-linux-64bit.tar.gz');
+		await validateVersion('1.3.2', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.3.2/camel-k-client-1.3.2-linux-64bit.tar.gz');
 	});
 
 	test("validate url for existing 1.4.0 version", async () => {
-		await validateVersion('1.4.0', 'linux', 'https://github.com/apache/camel-k/releases/download/v1.4.0/camel-k-client-1.4.0-linux-64bit.tar.gz');
+		await validateVersion('1.4.0', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.4.0/camel-k-client-1.4.0-linux-64bit.tar.gz');
+	});
+
+	test("validate url for existing 1.4.0 windows version", async () => {
+		await validateVersion('1.4.0', Platform.WINDOWS, 'https://github.com/apache/camel-k/releases/download/v1.4.0/camel-k-client-1.4.0-windows-64bit.tar.gz');
+	});
+
+	test("validate url for existing 1.4.0 MacOS version", async () => {
+		await validateVersion('1.4.0', Platform.MACOS, 'https://github.com/apache/camel-k/releases/download/v1.4.0/camel-k-client-1.4.0-mac-64bit.tar.gz');
 	});
 
 	test("validate invalid url for xyz1 version", async () => {
-		await invalidateVersion('xyz1', 'linux');
+		await invalidateVersion('xyz1', Platform.LINUX);
 	});
 
-	async function validateVersion(tagName : string, platformName : string, urlToTest : string): Promise<void> {
+	async function validateVersion(tagName: string, platform: Platform, urlToTest: string): Promise<void> {
 		try {
-			const testUrl = await versionUtils.getDownloadURLForCamelKTag(tagName, platformName);
+			const testUrl = await versionUtils.getDownloadURLForCamelKTag(tagName, platform);
 			should.equal(testUrl, urlToTest);
 		} catch (error) {
 			should.fail(error);
 		}
 	}
 
-	async function invalidateVersion(tagName : string, platformName : string): Promise<void> {
+	async function invalidateVersion(tagName: string, platform: Platform): Promise<void> {
 		try {
-			await versionUtils.getDownloadURLForCamelKTag(tagName, platformName);
+			await versionUtils.getDownloadURLForCamelKTag(tagName, platform);
 			should.fail(`Downloading invalid Camel-K version (${tagName}) did not fail!`);
 		} catch (error) {
 			should.exist(error);
-		}		
+		}
 	}
 });

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -21,8 +21,9 @@ import * as extension from './extension';
 import { Errorable, failed } from './errorable';
 import * as config from './config';
 import * as kamelCli from './kamel';
-import { platformString } from './installer';
+import { platform } from './installer';
 import fetch from 'cross-fetch';
+import { Platform } from './shell';
 
 export const version: string = '1.4.0'; //need to retrieve this if possible, but have a default
 
@@ -34,9 +35,9 @@ const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION: string = 'Tue, 20 Apr 2021 11:25:24
 let latestVersionFromOnline: string;
 
 export async function testVersionAvailable(versionToUse: string): Promise<boolean> {
-	if (platformString && versionToUse) {
+	if (platform && versionToUse) {
 		try {
-			const kamelUrl : string = await getDownloadURLForCamelKTag(versionToUse, platformString);
+			const kamelUrl : string = await getDownloadURLForCamelKTag(versionToUse, platform);
 			return await pingGithubUrl(kamelUrl);
 		} catch (error) {
 			// ignore
@@ -197,8 +198,21 @@ function setVersionAndTellUser(msg: string, newVersion: string) {
 	extension.setRuntimeVersionSetting(newVersion);
 }
 
-export async function getDownloadURLForCamelKTag(camelKVersion : string, platformStr : string): Promise<string> {
-	let tagName: string = isOldTagNaming(camelKVersion) ? camelKVersion : `v${camelKVersion}`;
+function toKamelOsString(platform: Platform | undefined): string | undefined {
+	switch (platform) {
+		case Platform.WINDOWS:
+			return 'windows';
+		case Platform.LINUX:
+			return 'linux';
+		case Platform.MACOS:
+			return 'mac';
+	}
+	return undefined;
+}
+
+export async function getDownloadURLForCamelKTag(camelKVersion : string, platform : Platform): Promise<string> {
+	const platformStr = toKamelOsString(platform);
+	const tagName: string = isOldTagNaming(camelKVersion) ? camelKVersion : `v${camelKVersion}`;
 	const tagURL: string = `https://api.github.com/repos/apache/camel-k/releases/tags/${tagName}`;
 	const headers: string[][] = [];
 	const githubToken: string | undefined = process.env.VSCODE_CAMELK_GITHUB_TOKEN;


### PR DESCRIPTION
    Use an enum to detected the OS platform

    Then decode it differently for kamel and kubectl.

    Fixes #769