### PR TITLE
FUSETOOLS2-1127 - hide debugger cmd from palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,12 @@
 					"group": "3_debuggroup@2",
 					"when": "view == camelk.integrations"
 				}
+			],
+			"commandPalette": [
+				{
+					"command": "camelk.integrations.debug.java",
+					"when": "never"
+				}
 			]
 		},
 		"taskDefinitions": [


### PR DESCRIPTION
Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>