### PR TITLE
FUSETOOLS2-1168 - Upgrade default yaml schema for files with camel-k

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 					},
 					"camelk.yaml.schema": {
 						"type": "string",
-						"default": "https://raw.githubusercontent.com/apache/camel-k-runtime/camel-k-runtime-parent-1.5.0/camel-k-loader-yaml/camel-k-loader-yaml/src/generated/resources/camel-yaml-dsl.json",
+						"default": "https://raw.githubusercontent.com/apache/camel/camel-3.10.0/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json",
 						"description": "Yaml Schema applied when Camel K modeline is set. (I.e. file starting with '# camel-k: ')"
 					}
 				}

--- a/src/test/suite/CamelKSchemaManager.test.ts
+++ b/src/test/suite/CamelKSchemaManager.test.ts
@@ -36,7 +36,7 @@ suite('Test Camel K Schema Manager', function () {
 
 	test('Default works', async () => {
 		const schema: string | undefined = await CamelKSchemaManager.requestYamlSchemaContentCallback(CAMELK_SCHEMA_URI_PREFIX);
-		expect(schema).to.contains('org.apache.camel.k.loader.yaml.parser.FromStepParser$Definition');
+		expect(schema).to.contains('org.apache.camel.model.FromDefinition');
 	});
 
 	test('Return no schema for not Camel K files', async () => {


### PR DESCRIPTION
modeline to Camel 3.10 version

The schema contains several modifications for several improvements and
new features. it will avoid users which relies on recent versions to
have troubles (such as in this issue
https://issues.apache.org/jira/browse/CAMEL-16741 )

For the future it would interesting to rely on the schemastore, see
https://issues.redhat.com/browse/FUSETOOLS2-1169

Signed-off-by: Aurélien Pupier <apupier@redhat.com>