### PR TITLE
FUSETOOSL2-1174 - fix regression of registering tutorial with Didact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 test-resources
 coverage
 test Fixture with speci@l chars/.vscode/settings.json
+.test-extensions

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -16,3 +16,4 @@ test-resources
 coverconfig.json
 coverage
 *.vsix
+.test-extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.26
 
-
+- Adapt Didact tutorial registration to VS Code Didact 0.4.0 updated API
 
 ## 0.0.25
 

--- a/package.json
+++ b/package.json
@@ -329,8 +329,8 @@
 		"watch": "tsc -watch -p ./",
 		"test": "npm run compile && node ./out/src/test/runTests.js",
 		"copy-sanitize": "copyfiles -u 1 src/test/suite/sanitize.go.saved out/src",
-		"ui-test": "npm run compile && extest setup-and-run './out/src/ui-test/*_test.js'",
-		"ui-test-insiders": "npm run compile && extest setup-and-run './out/src/ui-test/*_test.js' -t insider"
+		"ui-test": "npm run compile && node out/src/ui-test/uitest_runner.js",
+		"ui-test-insiders": "npm run compile && node out/src/ui-test/uitest_runner.js -t insider"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.2.19",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,6 @@ import { LogsPanel } from './logsWebview';
 import * as logUtils from './logUtils';
 import {checkKamelNeedsUpdate, version, handleChangeRuntimeConfiguration} from './versionUtils';
 import * as NewIntegrationFileCommand from './commands/NewIntegrationFileCommand';
-import * as path from 'path';
 import { registerCamelKSchemaProvider } from './CamelKSchemaManager';
 import * as telemetry from './Telemetry';
 export const DELAY_RETRY_KUBECTL_CONNECTION: number = 1000;
@@ -72,6 +71,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	applyUserSettings();
 
 	mainOutputChannel = vscode.window.createOutputChannel("Apache Camel K");
+	await installAllTutorials(context);
 	registerCamelKSchemaProvider(mainOutputChannel);
 	myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
 	context.subscriptions.push(myStatusBarItem);
@@ -207,8 +207,6 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 		}
 	});
-
-	await installAllTutorials(context);
 	
 	(await telemetry.getTelemetryServiceInstance()).sendStartupEvent();
 	
@@ -494,11 +492,10 @@ async function registerTutorialWithDidact(context: vscode.ExtensionContext, name
 		const didactExt: any = vscode.extensions.getExtension(extensionId);
 		if (didactExt) {
 			const commandId: string = 'vscode.didact.register';
-			const tutorialPath: string = path.join(context.extensionPath, extpath);
-			const tutorialUri: vscode.Uri = vscode.Uri.parse(`file://${tutorialPath}`);
+			const tutorialUri: vscode.Uri = vscode.Uri.file(context.asAbsolutePath(extpath));
 
-			// then pass name, uri, and category
-			await vscode.commands.executeCommand(commandId,	name, tutorialUri, category);
+			// then pass name, file system path, and category
+			await vscode.commands.executeCommand(commandId,	name, tutorialUri.fsPath, category);
 		}
 	} catch (error) {
 		console.log(error);

--- a/src/ui-test/camelk_didact_tutorial_test.ts
+++ b/src/ui-test/camelk_didact_tutorial_test.ts
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert, expect } from 'chai';
+import {
+	By,
+	ContextMenuItem,
+	EditorView,
+	until,
+	ViewItem,
+	ViewSection,
+	WebView
+} from 'vscode-extension-tester';
+import {
+	ActivityBar
+} from 'vscode-uitests-tooling';
+
+describe('Didact Tutorial of Camel K', function () {
+
+	let switchedContextWebview: WebView | undefined;
+	let handle: string | undefined;
+
+	after(async function () {
+		if (switchedContextWebview) {
+			await switchBackWithAWorkaround();
+			switchedContextWebview = undefined;
+		}
+		await new EditorView().closeAllEditors();
+	});
+
+	it('Check that Camel K Didact tutorial opens with some content', async function () {
+		this.timeout(30000);
+		await startTutorial();
+
+		const didactTutorialWebView = new WebView();
+		const expectedTitle = 'Apache Camel K';
+		expect(await didactTutorialWebView.getTitle()).equal(expectedTitle);
+
+		await checkContentOfTutorial(didactTutorialWebView, expectedTitle);
+	});
+
+	async function checkContentOfTutorial(didactTutorialWebView: WebView, expectedTitle: string) {
+		await switchToFrameWithAWorkaround(didactTutorialWebView);
+		switchedContextWebview = didactTutorialWebView;
+		const titleElement = await didactTutorialWebView.findWebElement(By.css('h1'));
+		expect(await titleElement.getText()).equal(expectedTitle);
+	}
+
+	/**
+	 * See https://github.com/redhat-developer/vscode-extension-tester/issues/301
+	 */
+	async function switchToFrameWithAWorkaround(didactTutorialWebView: WebView) {
+		handle = await didactTutorialWebView.getDriver().getWindowHandle();
+		await didactTutorialWebView.getDriver().wait(until.elementLocated(By.className('webview ready')), 10000);
+		const frame = await didactTutorialWebView.getDriver().findElement(By.className('webview ready'));
+		await didactTutorialWebView.getDriver().switchTo().frame(frame);
+
+		await didactTutorialWebView.getDriver().wait(until.elementLocated(By.id('active-frame')), 10000);
+		const activeFrame = await didactTutorialWebView.getDriver().findElement(By.id('active-frame'));
+		await didactTutorialWebView.getDriver().switchTo().frame(activeFrame);
+	}
+
+	/**
+	 * See https://github.com/redhat-developer/vscode-extension-tester/issues/301
+	 */
+	async function switchBackWithAWorkaround() {
+		if (switchedContextWebview !== undefined && handle !== undefined) {
+			switchedContextWebview.getDriver().switchTo().window(handle);
+		}
+	}
+});
+
+async function startTutorial(): Promise<void> {
+	const didactTutorialSectionView = await expandSectionViewInExplorerSideBar();
+	await expandCategory(didactTutorialSectionView, 'Apache Camel K');
+	const camelKTutorialItem = await didactTutorialSectionView.findItem('Your First Integration');
+	assert.isNotNull(camelKTutorialItem, 'Missing "Your First Integration" entry inside "Apache Camel K" category');
+	await (camelKTutorialItem as ViewItem).select();
+	await new EditorView().closeAllEditors(); // to close Demonstrating Didact tutorial which opens during activation of Didact extension
+	const contextMenu = await (camelKTutorialItem as ViewItem).openContextMenu();
+	const startDidactTutorialContextMenu = await contextMenu.getItem('Start Didact tutorial');
+	assert.isNotNull(startDidactTutorialContextMenu, '"Start Didact Tutorial" is nto part of contextual menu');
+	await (startDidactTutorialContextMenu as ContextMenuItem).click();
+	try {
+		await new EditorView().getDriver().wait(async() => {
+			return (await new EditorView().getOpenEditorTitles()).includes('Apache Camel K');
+		});
+	} catch(error) {
+		throw new Error('No editor with title "Apache Camel K" found');
+	}
+}
+
+async function expandCategory(didactTutorialSectionView: ViewSection, categoryCamelKDidact: string) {
+	// next line is a workaround to https://github.com/redhat-developer/vscode-extension-tester/issues/303
+	await didactTutorialSectionView.getDriver().wait(until.elementLocated(By.css('.monaco-list')), 10000);
+
+	await didactTutorialSectionView.getDriver().wait(async () => {
+		const viewItems: ViewItem[] = await didactTutorialSectionView?.getVisibleItems();
+		for (const viewItem of viewItems) {
+			if (await viewItem.getText() === categoryCamelKDidact) {
+				return true;
+			}
+		}
+		return false;
+	}, 10000);
+	await didactTutorialSectionView.openItem(categoryCamelKDidact);
+}
+
+async function expandSectionViewInExplorerSideBar(): Promise<ViewSection> {
+	const explorerControl = await new ActivityBar().getViewControl('Explorer');
+	const explorerView = await explorerControl.openView();
+	assert.isNotNull(explorerView, 'Cannot open Explorer View');
+	const didactTutorialSectionView = await explorerView.getContent().getSection('Didact Tutorials');
+	assert.isNotNull(didactTutorialSectionView, 'No "Didact Tutorials" section retrieved.')
+	await didactTutorialSectionView.expand();
+	return didactTutorialSectionView;
+}

--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import * as path from 'path';
+ import { ExTester } from 'vscode-extension-tester';
+ import { ReleaseQuality } from 'vscode-extension-tester/out/util/codeUtil';
+ 
+ const storageFolder = undefined;
+ let releaseType: ReleaseQuality = ReleaseQuality.Stable;
+ const projectPath = path.resolve(__dirname, '..', '..');
+ const extensionFolder = path.join(projectPath, '.test-extensions');
+ 
+ async function main(): Promise<void> {
+	 if(process.argv.length === 4){
+		 if(process.argv[2] === '-t' && process.argv[3] === 'insider') {
+			 releaseType = ReleaseQuality.Insider;
+		 }
+	 }
+	 const tester = new ExTester(storageFolder, releaseType, extensionFolder);
+	 await tester.setupRequirements();
+	 await tester.installFromMarketplace('redhat.vscode-didact');
+	 await tester.runTests('out/src/ui-test/*_test.js');
+ }
+ 
+ main();


### PR DESCRIPTION
0.4.0

- Didact API has been modified so need to adapt
- provide basic test checking that the tutorial is registered and can be
opened. It requires to install VS Code Didact when launching UI tests.
- Register Didact tutorial at the beginning of the activation. It allows
to have it available without waiting for a potential download of kamel
CLI
- 1 workaround is used in testing due to not immediate loading of
Tutorial content in webview and
redhat-developer/vscode-extension-tester#301
- 1 workaround is used in testing due to not immediate loading of Didact
View tree and
redhat-developer/vscode-extension-tester#303