### PR TITLE
FUSETOOLS2-1124 - store minikube cache in Circle CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
+          name: Restore npm cache
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      - restore_cache:
+          name: Restore minikube cache
+          key: minikube-cache-{{ checksum ".circleci/config.yml" }}
       - run:
           name: Install Node environment
           command: |
@@ -72,9 +76,15 @@ jobs:
                 name: test UI on Insider
                 command: npm run ui-test-insiders
       - save_cache:
+          name: Save npm cache
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm
+      - save_cache:
+          name: Save minikube cache
+          key: minikube-cache-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - ~/.minikube/cache
       - store_artifacts:
           path: /home/circleci/.config/Code/logs
           name: Store VS Code logs


### PR DESCRIPTION
Previously: [1'44"](https://app.circleci.com/pipelines/github/camel-tooling/vscode-camelk/946/workflows/72a0586c-2e45-462c-b482-cb42aa3fd417/jobs/1232/parallel-runs/0/steps/0-109) 

With PR when circleci conf is nto modified: [15"](https://app.circleci.com/pipelines/github/camel-tooling/vscode-camelk/946/workflows/80023851-4bca-4a89-80c2-42d9211cef3f/jobs/1234/parallel-runs/0/steps/0-103) + still [1'44"](https://app.circleci.com/pipelines/github/camel-tooling/vscode-camelk/946/workflows/80023851-4bca-4a89-80c2-42d9211cef3f/jobs/1234/parallel-runs/0/steps/0-109) :'-(