### PR TITLE
Fusetools2 1154 change red hat telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,4 +327,4 @@ Here's the current list of issues we're working to resolve. If you find a new is
 
 ## Data and telemetry
 
-The Project Initializer by Red Hat for Visual Studio Code collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the `redhat.elemetry.enabled` setting which you can learn more about at https://github.com/redhat-developer/vscode-commons#how-to-disable-telemetry-reporting
+The Tooling for Apache Camel K by Red Hat for Visual Studio Code collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the `redhat.telemetry.enabled` setting which you can learn more about at https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -1,6 +1,8 @@
-## [Tooling for Apache Camel K by Red Hat](https://github.com/camel-tooling/vscode-camelk)
+# Data collection
 
-### Usage Data
+vscode-camelk has opt-in telemetry collection, provided by [vscode-redhat-telemetry](https://github.com/redhat-developer/vscode-redhat-telemetry).
+
+### What's included in the vsocde-camelk telemetry data
 
 * when extension is activated
 * when a command from this extension is used, the command id is provided
@@ -9,3 +11,11 @@
 * when `Start Apache Camel K integration` command contributed by extension is executed
     * with the language of the file deployed
     * with the kind (basic, dev, ...)
+
+## What's included in the general telemetry data
+
+Please see the [vscode-redhat-telemetry data collection information](https://github.com/redhat-developer/vscode-redhat-telemetry/blob/HEAD/USAGE_DATA.md) for information on what data it collects.
+
+## How to opt in or out
+
+Use the `redhat.telemetry.enabled` setting in order to enable or disable telemetry collection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
 			}
 		},
 		"@redhat-developer/vscode-redhat-telemetry": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.1.1.tgz",
-			"integrity": "sha512-uMJNiFNUXCYy/4KZaX+Ctueq+KXIWyS5Cfv2wqHNNzpV9+EhPLHUJoZKbCMY/P+IlgqTWYfpDkghZHiq5ChvEA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.2.0.tgz",
+			"integrity": "sha512-qS9p+iXpdMwCzhVRr/Ft5dMQQXB+6CxBRnpp3NDUuxYP1s/K/B1dPlIW5lKncjPUwYaKvPbpMgGGDmsosOzT8A==",
 			"requires": {
 				"@types/analytics-node": "^3.1.4",
 				"analytics-node": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
 		"redhat.vscode-commons"
 	],
 	"dependencies": {
-		"@redhat-developer/vscode-redhat-telemetry": "^0.1.1",
+		"@redhat-developer/vscode-redhat-telemetry": "^0.2.0",
 		"@types/detect-port": "^1.3.1",
 		"@types/request-promise": "^4.1.47",
 		"@types/shelljs": "^0.8.9",

--- a/package.json
+++ b/package.json
@@ -365,8 +365,7 @@
 	},
 	"extensionDependencies": [
 		"ms-kubernetes-tools.vscode-kubernetes-tools",
-		"redhat.vscode-yaml",
-		"redhat.vscode-commons"
+		"redhat.vscode-yaml"
 	],
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.2.0",

--- a/src/CamelKTelemetry.ts
+++ b/src/CamelKTelemetry.ts
@@ -15,27 +15,29 @@
  * limitations under the License.
  */
 
-import { TelemetryEvent, getRedHatService, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry/lib';
-import { ExtensionContext } from 'vscode';
+import { TelemetryEvent, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry/lib';
 
-
-export let telemetryService: Promise<TelemetryService>;
-
-export async function registerTelemetryService(context: ExtensionContext) {
-	telemetryService = (await getRedHatService(context)).getTelemetryService();
+export class CamelKTelemetry {
+	
+	private telemetryService: Promise<TelemetryService>;
+	
+	public constructor(telemetryService: Promise<TelemetryService>) {
+		this.telemetryService = telemetryService;
+	}
+	
+	public async getTelemetryServiceInstance(): Promise<TelemetryService> {
+		return this.telemetryService;
+	}
+	
+	public async sendCommandTracking(commandId: string) {
+		const telemetryEvent: TelemetryEvent = {
+			type: 'track',
+			name: 'command',
+			properties: {
+				identifier: commandId
+			}
+		};
+		(await this.telemetryService).send(telemetryEvent);
+	}
 }
 
-export async function getTelemetryServiceInstance(): Promise<TelemetryService> {
-    return telemetryService;
-}
-
-export async function sendCommandTracking(commandId: string) {
-	const telemetryEvent: TelemetryEvent = {
-		type: 'track',
-		name: 'command',
-		properties: {
-			identifier: commandId
-		}
-	};
-	(await telemetryService).send(telemetryEvent);
-}

--- a/src/ConfigMapAndSecrets.ts
+++ b/src/ConfigMapAndSecrets.ts
@@ -22,7 +22,6 @@ import * as extension from './extension';
 import * as utils from './CamelKJSONUtils';
 import { isKubernetesAvailable } from './kubectlutils';
 import { ShellResult } from './shell';
-import * as telemetry from './Telemetry';
 
 export const validNameRegex: RegExp = /^[A-Za-z][A-Za-z0-9\-]*(?:[A-Za-z0-9]$){1}/;
 const COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE = 'camelk.integrations.createconfigmapfromfile';
@@ -34,21 +33,21 @@ export function registerCommands(): void {
 	// create the integration view action -- create new configmap from file or folder
 	vscode.commands.registerCommand(COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE, (uri:vscode.Uri) => {
 		createConfigMapFromUri(uri);
-		telemetry.sendCommandTracking(COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE);
+		extension.getTelemetry().sendCommandTracking(COMMAND_ID_CREATE_CONFIG_MAP_FROM_FILE);
 	});
 	vscode.commands.registerCommand(COMMAND_ID_CREATE_CONFIGMAP_FROM_FOLDER, (uri:vscode.Uri) => {
 		createConfigMapFromUri(uri);
-		telemetry.sendCommandTracking(COMMAND_ID_CREATE_CONFIGMAP_FROM_FOLDER);
+		extension.getTelemetry().sendCommandTracking(COMMAND_ID_CREATE_CONFIGMAP_FROM_FOLDER);
 	});
 
 	// create the integration view action -- create new secret from file or folder
 	vscode.commands.registerCommand(COMMAND_ID_CREATE_SECRET_FROM_FILE, (uri:vscode.Uri) => {
 		createSecretFromUri(uri);
-		telemetry.sendCommandTracking(COMMAND_ID_CREATE_SECRET_FROM_FILE);
+		extension.getTelemetry().sendCommandTracking(COMMAND_ID_CREATE_SECRET_FROM_FILE);
 	});
 	vscode.commands.registerCommand(COMMAND_ID_CREATE_SECRET_FROM_FOLDER, (uri:vscode.Uri) => {
 		createSecretFromUri(uri);
-		telemetry.sendCommandTracking(COMMAND_ID_CREATE_SECRET_FROM_FOLDER);
+		extension.getTelemetry().sendCommandTracking(COMMAND_ID_CREATE_SECRET_FROM_FOLDER);
 	});
 }
 

--- a/src/IntegrationUtils.ts
+++ b/src/IntegrationUtils.ts
@@ -26,7 +26,6 @@ import * as k8s from 'vscode-kubernetes-tools-api';
 import * as kamel from './kamel';
 import { CamelKRunTaskProvider, CamelKRunTaskDefinition } from './task/CamelKRunTaskDefinition';
 import * as fs from 'fs';
-import { getTelemetryServiceInstance } from './Telemetry';
 import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
 
 const validNameRegex = /^[A-Za-z][A-Za-z0-9\-\.]*(?:[A-Za-z0-9]$){1}/;
@@ -218,7 +217,7 @@ const choiceList = [
 }
 
 async function sendStartIntegrationTelemetryEvent(choice: string, context: vscode.Uri) {
-	const telemetryService = await getTelemetryServiceInstance();
+	const telemetryService = await extension.getTelemetry().getTelemetryServiceInstance();
 	const telemetryEvent: TelemetryEvent = {
 		type: 'track',
 		name: 'command',

--- a/src/Telemetry.ts
+++ b/src/Telemetry.ts
@@ -15,10 +15,15 @@
  * limitations under the License.
  */
 
-import { TelemetryService, getTelemetryService, TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
+import { TelemetryEvent, getRedHatService, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry/lib';
+import { ExtensionContext } from 'vscode';
 
 
-export const telemetryService: Promise<TelemetryService> = getTelemetryService('redhat.vscode-camelk');
+export let telemetryService: Promise<TelemetryService>;
+
+export async function registerTelemetryService(context: ExtensionContext) {
+	telemetryService = (await getRedHatService(context)).getTelemetryService();
+}
 
 export async function getTelemetryServiceInstance(): Promise<TelemetryService> {
     return telemetryService;

--- a/src/commands/NewIntegrationFileCommand.ts
+++ b/src/commands/NewIntegrationFileCommand.ts
@@ -17,11 +17,11 @@
 'use strict';
 
 import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
+import * as camelKExtension from '../extension';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as kamel from '../kamel';
-import { getTelemetryServiceInstance } from '../Telemetry';
 
 const validFilename = require('valid-filename');
 
@@ -75,7 +75,7 @@ export async function create(...args: any[]) : Promise<void> {
 		await kamelExecutor.invoke(`init "${newFileFullPath}"`);
 		const textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(newFileFullPath);
 		await vscode.window.showTextDocument(textDocument);
-		const telemetryService = await getTelemetryServiceInstance();
+		const telemetryService = await camelKExtension.getTelemetry().getTelemetryServiceInstance();
 		const telemetryEvent: TelemetryEvent = {
 			type: 'track',
 			name: 'command',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,6 +208,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 	
+	await telemetry.registerTelemetryService(context);
 	(await telemetry.getTelemetryServiceInstance()).sendStartupEvent();
 	
 	return {

--- a/src/test/runTests.ts
+++ b/src/test/runTests.ts
@@ -23,7 +23,6 @@ async function main() : Promise<void> {
 		installExtraExtension(cliPath, 'ms-kubernetes-tools.vscode-kubernetes-tools');
 		installExtraExtension(cliPath, 'redhat.java');
 		installExtraExtension(cliPath, 'vscjava.vscode-java-debug');
-		installExtraExtension(cliPath, 'redhat.vscode-commons');
 
 		await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath, launchArgs: [testWorkspace] });
 

--- a/src/test/suite/DebugIntegration.test.ts
+++ b/src/test/suite/DebugIntegration.test.ts
@@ -24,7 +24,6 @@ import * as extension from '../../extension';
 import * as Utils from "./Utils";
 import * as shelljs from 'shelljs';
 import { LANGUAGES_WITH_FILENAME_EXTENSIONS } from '../../commands/NewIntegrationFileCommand';
-import { getTelemetryServiceInstance } from '../../Telemetry';
 import { cleanDeployedIntegration, createFile, startIntegrationWithBasicCheck, checkTelemetry, retrieveDeployedTreeNodes} from './Utils/DeployTestUtil';
 import { CamelKDebugTaskProvider } from '../../task/CamelKDebugTaskDefinition';
 import { waitUntil } from 'async-wait-until';
@@ -54,7 +53,7 @@ suite('Check can debug default Java example', () => {
 		showWorkspaceFolderPickStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
 		// Workaround due to bug in shelljs: https://github.com/shelljs/shelljs/issues/704
 		shelljs.config.execPath = shelljs.which('node').toString();
-		telemetrySpy = sinon.spy(await getTelemetryServiceInstance(), 'send');
+		telemetrySpy = sinon.spy(await(await Utils.getTelemetry()).getTelemetryServiceInstance(), 'send');
 		debugConfigurationTaskExecution = undefined;
 	});
 

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -26,11 +26,11 @@ import { assert, expect } from 'chai';
 import { waitUntil } from 'async-wait-until';
 import { getNamedListFromKubernetesThenParseList } from '../../kubectlutils';
 import * as shelljs from 'shelljs';
+import * as Utils from './Utils';
 import * as kamel from './../../kamel';
 import * as kubectl from './../../kubectl';
 import { LANGUAGES, LANGUAGES_WITH_FILENAME_EXTENSIONS } from '../../commands/NewIntegrationFileCommand';
 import * as CamelKRunTaskDefinition from '../../task/CamelKRunTaskDefinition';
-import { getTelemetryServiceInstance } from '../../Telemetry';
 import { cleanDeployedIntegration, createFile, startIntegrationWithBasicCheck, checkTelemetry, checkIntegrationDeployed, checkIntegrationRunning } from './Utils/DeployTestUtil';
 
 export const RUNNING_TIMEOUT: number = 720000;
@@ -57,7 +57,7 @@ suite('Check can deploy default examples', () => {
 		showWorkspaceFolderPickStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
 		// Workaround due to bug in shelljs: https://github.com/shelljs/shelljs/issues/704
 		shelljs.config.execPath = shelljs.which('node').toString();
-		telemetrySpy = sinon.spy(await getTelemetryServiceInstance(), 'send');
+		telemetrySpy = sinon.spy(await(await Utils.getTelemetry()).getTelemetryServiceInstance(), 'send');
 	});
 
 	teardown(async () => {

--- a/src/test/suite/Utils.ts
+++ b/src/test/suite/Utils.ts
@@ -21,6 +21,7 @@ import * as vscode from 'vscode';
 import os = require('os');
 import { CamelKNodeProvider, TreeNode } from '../../CamelKNodeProvider';
 import { waitUntil } from 'async-wait-until';
+import { CamelKTelemetry } from '../../CamelKTelemetry';
 
 const extensionId = 'redhat.vscode-camelk';
 export const ACTIVATION_TIMEOUT = 45000;
@@ -75,6 +76,11 @@ export function getCamelKIntegrationsTreeView(): vscode.TreeView<TreeNode | unde
 export async function getIntegrationsFromKubectlCliWithWatchTestApi(): Promise<void> {
 	const extension = retrieveCamelKExtension();
 	return extension?.exports.getIntegrationsFromKubectlCliWithWatchTestApi();
+}
+
+export async function getTelemetry(): Promise<CamelKTelemetry> {
+	const extension = retrieveCamelKExtension();
+	return extension?.exports.getTelemetry();
 }
 
 function retrieveCamelKExtension(): vscode.Extension<any> | undefined {

--- a/src/test/suite/commands/NewIntegrationFileCommand.test.ts
+++ b/src/test/suite/commands/NewIntegrationFileCommand.test.ts
@@ -17,13 +17,13 @@
 'use strict';
 
 import { expect } from "chai";
+import * as Utils from './../Utils';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { fail } from "assert";
 import { waitUntil } from 'async-wait-until';
 import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
-import { getTelemetryServiceInstance } from "../../../Telemetry";
 
 const os = require('os');
 
@@ -36,10 +36,11 @@ suite('Test command to create an Apache Camel K integration file', function() {
 	let createdFile: vscode.Uri;
 
 	setup(async () => {
+		Utils.ensureExtensionActivated();
 		showQuickpickStub = sinon.stub(vscode.window, 'showQuickPick');
 		showInputBoxStub = sinon.stub(vscode.window, 'showInputBox');
 		showWorkspaceFolderPickStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
-		telemetrySpy = sinon.spy(await getTelemetryServiceInstance(), 'send');
+		telemetrySpy = sinon.spy(await(await Utils.getTelemetry()).getTelemetryServiceInstance(), 'send');
 	});
 
 	teardown(async () => {


### PR DESCRIPTION
- remove dependency on vscode-commons as now the standalone npm library is recommended
- it required to upgrade dependencies
- Given that now the Telemetry Service requires the extension context,
the way to mock the service is more complicated (at least not found an
easier way)