### PR TITLE
Fusetools2 679 and FUSETOOLS2-1191 check start integration with property and remove the wrong double-quotes

### DIFF
--- a/src/IntegrationUtils.ts
+++ b/src/IntegrationUtils.ts
@@ -323,7 +323,8 @@ function getSelectedProperties(): Promise<string[]> {
 				});
 				if (propValue) {
 					propValue = propValue.replace(/"/g, '\\"');
-					let newProperty = `${propName}="${propValue}"`;
+					console.log(propValue);
+					let newProperty = `${propName}=${propValue}`;
 
 					const moreProperties: string | undefined = await vscode.window.showQuickPick(['No', 'Yes'], {
 						placeHolder: 'Are there more properties?',

--- a/src/IntegrationUtils.ts
+++ b/src/IntegrationUtils.ts
@@ -35,7 +35,7 @@ export const basicIntegration: string = 'Basic - Apache Camel K Integration with
 export const configMapIntegration: string = 'ConfigMap - Apache Camel K Integration with Kubernetes ConfigMap';
 export const secretIntegration: string = 'Secret - Apache Camel K Integration with Kubernetes Secret';
 const resourceIntegration: string = 'Resource - Apache Camel K Integration with Resource file';
-const propertyIntegration: string = 'Property - Apache Camel K Integration with Property';
+export const propertyIntegration: string = 'Property - Apache Camel K Integration with Property';
 const dependencyIntegration: string = 'Dependencies - Apache Camel K Integration with Explicit Dependencies';
 export const vscodeTasksIntegration: string = 'Use a predefined Task - useful for multi-attributes deployment';
 
@@ -313,44 +313,40 @@ function getSelectedProperties(): Promise<string[]> {
 		let returnedProperties : string[] = [];
 
 		while (hasMoreProperties) {
-			let newProperty: string;
-			await vscode.window.showInputBox({
+			const propName: string | undefined = await vscode.window.showInputBox({
 				placeHolder: 'Specify the property name',
 				validateInput: validateName
-			}).then ( async (propName) => {
-				if (propName) {
-					await vscode.window.showInputBox({
-						placeHolder: 'Specify the property value'
-					}).then ( async (propValue) => {
-						if (propValue) {
-							propValue = propValue.replace(/"/g, '\\"');
-							newProperty = `${propName}="${propValue}"`;
+			});
+			if (propName) {
+				let propValue: string | undefined = await vscode.window.showInputBox({
+					placeHolder: 'Specify the property value'
+				});
+				if (propValue) {
+					propValue = propValue.replace(/"/g, '\\"');
+					let newProperty = `${propName}="${propValue}"`;
 
-							await vscode.window.showQuickPick( ['No', 'Yes'], {
-								placeHolder: 'Are there more properties?',
-								canPickMany : false	}).then( (answer) => {
-									if (!answer) {
-										hasMoreProperties = false;
-										reject(new Error(`No Property answer given`));
-									} else {
-										returnedProperties.push(newProperty);
-										if (answer && answer.toLowerCase() === 'no') {
-											hasMoreProperties = false;
-											resolve(returnedProperties);
-										}
-									}
-								});
-
-						} else {
-							hasMoreProperties = false;
-							reject(new Error(`No Property Value provided`));
-						}
+					const moreProperties: string | undefined = await vscode.window.showQuickPick(['No', 'Yes'], {
+						placeHolder: 'Are there more properties?',
+						canPickMany: false
 					});
+					if (!moreProperties) {
+						hasMoreProperties = false;
+						reject(new Error(`No Property answer given`));
+					} else {
+						returnedProperties.push(newProperty);
+						if (moreProperties && moreProperties.toLowerCase() === 'no') {
+							hasMoreProperties = false;
+							resolve(returnedProperties);
+						}
+					}
 				} else {
 					hasMoreProperties = false;
-					reject(new Error(`No Property Name provided`));
+					reject(new Error(`No Property Value provided`));
 				}
-			});
+			} else {
+				hasMoreProperties = false;
+				reject(new Error(`No Property Name provided`));
+			}
 		}
 	});
 }

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -153,7 +153,7 @@ suite('Check can deploy default examples', () => {
 		assert.isEmpty(getCamelKIntegrationsProvider().getTreeNodes());
 		showQuickpickStub.onSecondCall().returns(IntegrationUtils.propertyIntegration);
 		showInputBoxStub.onSecondCall().returns('propertyKey');
-		showInputBoxStub.onThirdCall().returns('myValueKey');
+		showInputBoxStub.onThirdCall().returns('my Value');
 		showQuickpickStub.onThirdCall().returns("No");
 		
 	 	await vscode.commands.executeCommand('camelk.startintegration');
@@ -188,7 +188,8 @@ async function checkConfigMapAvailableForDeployedIntegration() {
 async function checkPropertyAvailableAvailableForDeployedIntegration() {
 	const describeShell = shelljs.exec(`${await kamel.create().getPath()} describe integration test-java-deploy-with-property`);
 	const description: string = describeShell.stdout;
-	expect(description.replace(lineReturnAndSpaces, '')).includes('Configuration:Type:propertyValue:propertyKey=myValueKey');
+	expect(description).includes('propertyKey=my Value');
+	expect(description.replace(lineReturnAndSpaces, '')).includes('Configuration:Type:propertyValue:propertyKey=myValue');
 }
 
 function createConfigMap(kubectlPath: string, confimapName: string) {


### PR DESCRIPTION
based on https://github.com/camel-tooling/vscode-camelk/pull/821

done the FUSETOOLS2-679 and FUSETOOLS2-1191 in the mean time, as writing a test which is checking a wrong behavior doesn't make a lot of sense

![startIntegrationWithProperty](https://user-images.githubusercontent.com/1105127/124576494-a5794100-de4c-11eb-9b44-00a73d554b96.gif)
