### PR TITLE
Fusetools2 1202 simplify code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,24 +209,6 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 	
 	(await telemetry.getTelemetryServiceInstance()).sendStartupEvent();
-	
-	return {
-		getStashedContext() : vscode.ExtensionContext {
-			return stashedContext;
-		},
-		getCamelKIntegrationsProvider(): CamelKNodeProvider {
-			return camelKIntegrationsProvider;
-		},
-		getCamelKIntegrationsTreeView(): vscode.TreeView<TreeNode | undefined>{
-			return camelKIntegrationsTreeView;
-		},
-		getIntegrationsFromKubectlCliWithWatchTestApi(): Promise<void> {
-			return getIntegrationsFromKubectlCliWithWatch();
-		},
-		getMainOutputChannel(): vscode.OutputChannel {
-			return mainOutputChannel;
-		}
-	};
 }
 
 function retrieveIntegratioName(selection: TreeNode) {

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -16,12 +16,13 @@
  */
 'use strict';
 
+import * as extension from '../../extension';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as config from '../../config';
 import * as IntegrationUtils from '../../IntegrationUtils';
-import { skipOnJenkins, getCamelKIntegrationsProvider, openCamelKTreeView } from "./Utils";
+import { skipOnJenkins, openCamelKTreeView } from "./Utils";
 import { assert, expect } from 'chai';
 import { waitUntil } from 'async-wait-until';
 import { getNamedListFromKubernetesThenParseList } from '../../kubectlutils';
@@ -90,7 +91,7 @@ suite('Check can deploy default examples', () => {
 		const language = 'Java';
 		createdFile = await createFile(showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, `Test${language}DeployFromTask`, language);
 		await openCamelKTreeView();
-		assert.isEmpty(getCamelKIntegrationsProvider().getTreeNodes());
+		assert.isEmpty(extension.camelKIntegrationsProvider.getTreeNodes());
 		showQuickpickStub.onSecondCall().returns(IntegrationUtils.vscodeTasksIntegration);
 		showQuickpickStub.onThirdCall().returns(CamelKRunTaskDefinition.NAME_OF_PROVIDED_TASK_TO_DEPLOY_IN_DEV_MODE_FROM_ACTIVE_EDITOR);
 		
@@ -109,7 +110,7 @@ suite('Check can deploy default examples', () => {
 		createConfigMap(kubectlPath, confimapName);
 		
 		await openCamelKTreeView();
-		assert.isEmpty(getCamelKIntegrationsProvider().getTreeNodes());
+		assert.isEmpty(extension.camelKIntegrationsProvider.getTreeNodes());
 		showQuickpickStub.onSecondCall().returns(IntegrationUtils.configMapIntegration);
 		showQuickpickStub.onThirdCall().returns(confimapName);
 		
@@ -132,7 +133,7 @@ suite('Check can deploy default examples', () => {
 		createSecret(kubectlPath, secretName);
 		
 		await openCamelKTreeView();
-		assert.isEmpty(getCamelKIntegrationsProvider().getTreeNodes());
+		assert.isEmpty(extension.camelKIntegrationsProvider.getTreeNodes());
 		showQuickpickStub.onSecondCall().returns(IntegrationUtils.secretIntegration);
 		showQuickpickStub.onThirdCall().returns(secretName);
 		
@@ -150,7 +151,7 @@ suite('Check can deploy default examples', () => {
 		createdFile = await createFile(showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, `Test${language}DeployWithProperty`, language);
 		
 		await openCamelKTreeView();
-		assert.isEmpty(getCamelKIntegrationsProvider().getTreeNodes());
+		assert.isEmpty(extension.camelKIntegrationsProvider.getTreeNodes());
 		showQuickpickStub.onSecondCall().returns(IntegrationUtils.propertyIntegration);
 		showInputBoxStub.onSecondCall().returns('propertyKey');
 		showInputBoxStub.onThirdCall().returns('my Value');

--- a/src/test/suite/StartIntegrationWithResource.test.ts
+++ b/src/test/suite/StartIntegrationWithResource.test.ts
@@ -16,12 +16,13 @@
  */
 'use strict';
 
+import * as extension from '../../extension';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as config from '../../config';
 import * as IntegrationUtils from '../../IntegrationUtils';
-import { skipOnJenkins, getCamelKIntegrationsProvider, openCamelKTreeView } from "./Utils";
+import { skipOnJenkins, openCamelKTreeView } from "./Utils";
 import { assert, expect } from 'chai';
 import * as shelljs from 'shelljs';
 import * as kamel from '../../kamel';
@@ -98,7 +99,7 @@ async function testDeployWithResources(resources: tmp.FileResult[], showQuickpic
 	let createdFile: vscode.Uri | undefined = await createFile(showQuickpickStub, showWorkspaceFolderPickStub, showInputBoxStub, `Test${language}DeployWithResources`, language);
 
 	await openCamelKTreeView();
-	assert.isEmpty(getCamelKIntegrationsProvider().getTreeNodes());
+	assert.isEmpty(extension.camelKIntegrationsProvider.getTreeNodes());
 	showQuickpickStub.onSecondCall().returns(IntegrationUtils.resourceIntegration);
 	showOpenDialogStub.onFirstCall().returns(uriOfResources);
 

--- a/src/test/suite/Utils.ts
+++ b/src/test/suite/Utils.ts
@@ -19,7 +19,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import os = require('os');
-import { CamelKNodeProvider, TreeNode } from '../../CamelKNodeProvider';
 import { waitUntil } from 'async-wait-until';
 
 const extensionId = 'redhat.vscode-camelk';
@@ -51,34 +50,6 @@ async function waitInCaseExtensionIsActivating(extension: vscode.Extension<any>)
 	}, ACTIVATION_TIMEOUT).catch(() => {
 		console.log('Extension has not started automatically, we will force call to activate it.');
 	});
-}
-export function retrieveExtensionContext(): vscode.ExtensionContext {
-	const extension = retrieveCamelKExtension();
-	return extension?.exports.getStashedContext();
-}
-
-export function getCamelKIntegrationsProvider(): CamelKNodeProvider {
-	const extension = retrieveCamelKExtension();
-	return extension?.exports.getCamelKIntegrationsProvider();
-}
-
-export function getCamelKMainOutputChannel(): vscode.OutputChannel {
-	const extension = retrieveCamelKExtension();
-	return extension?.exports.getMainOutputChannel();
-}
-
-export function getCamelKIntegrationsTreeView(): vscode.TreeView<TreeNode | undefined> {
-	const extension = retrieveCamelKExtension();
-	return extension?.exports.getCamelKIntegrationsTreeView();
-}
-
-export async function getIntegrationsFromKubectlCliWithWatchTestApi(): Promise<void> {
-	const extension = retrieveCamelKExtension();
-	return extension?.exports.getIntegrationsFromKubectlCliWithWatchTestApi();
-}
-
-function retrieveCamelKExtension(): vscode.Extension<any> | undefined {
-	return vscode.extensions.getExtension('redhat.vscode-camelk');
 }
 
 export async function openCamelKTreeView() {

--- a/src/test/suite/Utils/DeployTestUtil.ts
+++ b/src/test/suite/Utils/DeployTestUtil.ts
@@ -18,7 +18,7 @@
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as IntegrationUtils from '../../../IntegrationUtils';
-import { getCamelKIntegrationsProvider, openCamelKTreeView } from "../Utils";
+import { openCamelKTreeView } from "../Utils";
 import { assert, expect } from 'chai';
 import { waitUntil } from 'async-wait-until';
 import * as extension from '../../../extension';
@@ -37,7 +37,7 @@ export async function cleanDeployedIntegration(telemetrySpy: sinon.SinonSpy) {
 		});
 		try {
 			await waitUntil(() => {
-				return getCamelKIntegrationsProvider().getTreeNodes().length === 0 && telemetrySpy.callCount === deployedTreeNodes?.length;
+				return extension.camelKIntegrationsProvider.getTreeNodes().length === 0 && telemetrySpy.callCount === deployedTreeNodes?.length;
 			}, UNDEPLOY_TIMEOUT);
 		} catch (error) {
 			console.log('Error while trying to remove deployed integrations, it remains:');
@@ -53,7 +53,7 @@ export async function retrieveDeployedTreeNodes(minimalExpectedTreeNode =1): Pro
 	let deployedTreeNodes: TreeNode[] = [];
 	try {
 		await waitUntil(() => {
-			deployedTreeNodes = getCamelKIntegrationsProvider().getTreeNodes();
+			deployedTreeNodes = extension.camelKIntegrationsProvider.getTreeNodes();
 			return deployedTreeNodes.length >= minimalExpectedTreeNode;
 		}, PROVIDER_POPULATED_TIMEOUT);
 	} catch (err) {
@@ -66,10 +66,10 @@ export async function startIntegrationWithBasicCheck(showQuickpickStub: sinon.Si
 	await openCamelKTreeView();
 	try {
 		await waitUntil(() => {
-			return getCamelKIntegrationsProvider().getTreeNodes().length === alreadyDeployedIntegration;
+			return extension.camelKIntegrationsProvider.getTreeNodes().length === alreadyDeployedIntegration;
 		});
 	} catch(error) {
-		const currentIntegrations = getCamelKIntegrationsProvider().getTreeNodes();
+		const currentIntegrations = extension.camelKIntegrationsProvider.getTreeNodes();
 		assert.equal(
 			currentIntegrations.length,
 			alreadyDeployedIntegration,
@@ -86,17 +86,17 @@ export async function startIntegrationWithBasicCheck(showQuickpickStub: sinon.Si
 export async function checkIntegrationRunning(indexOfNewDeployedIntegration :number) {
 	try {
 		await waitUntil(() => {
-			return getCamelKIntegrationsProvider().getTreeNodes()[indexOfNewDeployedIntegration]?.status === "Running";
+			return extension.camelKIntegrationsProvider.getTreeNodes()[indexOfNewDeployedIntegration]?.status === "Running";
 		}, RUNNING_TIMEOUT, 1000);
 	} catch (error) {
-		assert.fail(`The integration has not been marked as Running in Camel K Integration provided view. Current status ${getCamelKIntegrationsProvider().getTreeNodes()[0].status} \n${error}`);
+		assert.fail(`The integration has not been marked as Running in Camel K Integration provided view. Current status ${extension.camelKIntegrationsProvider.getTreeNodes()[0].status} \n${error}`);
 	}
 }
 
 export async function checkIntegrationDeployed(expectedDeployedIntegration :number) {
 	try {
 		await waitUntil(() => {
-			return getCamelKIntegrationsProvider().getTreeNodes()?.length === expectedDeployedIntegration;
+			return extension.camelKIntegrationsProvider.getTreeNodes()?.length === expectedDeployedIntegration;
 		}, DEPLOYED_TIMEOUT, 1000);
 	} catch (error) {
 		assert.fail('No integration has shown up in Camel K Integration provider view. (Nota: it requires that Camel K instance is reachable.)\n' + error);

--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -16,6 +16,7 @@
  */
 'use strict';
 
+import * as extension from '../../../extension';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as JavaDependenciesManager from '../../../JavaDependenciesManager';
@@ -95,7 +96,7 @@ async function testCompletion(
 	await checkExpectedCompletion(docUri, position, expectedCompletion);
 
 	function retrieveDestination() {
-		const context = Utils.retrieveExtensionContext();
+		const context = extension.getStashedContext();
 		return JavaDependenciesManager.destinationFolderForDependencies(context);
 	}
 }

--- a/src/test/suite/integrationExplorer.test.ts
+++ b/src/test/suite/integrationExplorer.test.ts
@@ -16,6 +16,7 @@
  */
 import * as vscode from 'vscode';
 import * as chai from 'chai';
+import * as extension from '../../extension';
 import * as CamelKNodeProvider from '../../CamelKNodeProvider';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
@@ -35,7 +36,7 @@ suite('Camel-k Integrations View', () => {
 	setup(() => {
 		Utils.ensureExtensionActivated();
 		sandbox = sinon.createSandbox();
-		integrationExplorer = Utils.getCamelKIntegrationsProvider();
+		integrationExplorer = extension.camelKIntegrationsProvider;
 		integrationExplorer.setRetrieveIntegrations(false);
 	});
 
@@ -81,7 +82,7 @@ suite('Camel-k Integrations View', () => {
 });
 
 function checkIConForPodStatus(status: string) {
-	const context = Utils.retrieveExtensionContext();
+	const context = extension.getStashedContext();
 	let iconPath = CamelKNodeProvider.TreeNode.getIconForPodStatus(status, context);
 	assert.notEqual(iconPath, undefined);
 	if (iconPath) {

--- a/src/test/suite/kubectlwatcher.test.ts
+++ b/src/test/suite/kubectlwatcher.test.ts
@@ -38,8 +38,8 @@ suite("Kubectl integration watcher", function() {
 
 	this.beforeEach(() => {
 		sandbox = sinon.createSandbox();
-		refreshStub = sandbox.stub(Utils.getCamelKIntegrationsProvider(), 'refresh');
-		messageStub = sandbox.stub(Utils.getCamelKMainOutputChannel(), 'append');
+		refreshStub = sandbox.stub(extension.camelKIntegrationsProvider, 'refresh');
+		messageStub = sandbox.stub(extension.mainOutputChannel, 'append');
 	});
 	
 	this.afterEach(() => {
@@ -58,7 +58,7 @@ suite("Kubectl integration watcher", function() {
 	
 	test('Check there is one set of message logged in case of connection error', async function() {
 		invalidateKubeConfigFileByRenamingIt(kubeconfigFilePath);
-		await Utils.getIntegrationsFromKubectlCliWithWatchTestApi();
+		await extension.getIntegrationsFromKubectlCliWithWatch();
 		checkErrorMessageLogged(messageStub);
 	});
 	
@@ -74,7 +74,7 @@ suite("Kubectl integration watcher", function() {
 		invalidateKubeConfigFileByRenamingIt(kubeconfigFilePath);
 		await Utils.openCamelKTreeView();
 		messageStub.resetHistory();
-		await Utils.getIntegrationsFromKubectlCliWithWatchTestApi();
+		await extension.getIntegrationsFromKubectlCliWithWatch();
 		checkErrorMessageLogged(messageStub);
 	});
 	


### PR DESCRIPTION
based on https://github.com/camel-tooling/vscode-camelk/pull/842

Now that istnabul code coverage is removed, the spy in tests can be simplified. it also avoids to expose internal things in the extension API even if marked as "only for test"