### PR TITLE
FUSETOOLS2-1154 - Upgrade red hat telemetry to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
 			}
 		},
 		"@redhat-developer/vscode-redhat-telemetry": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.1.1.tgz",
-			"integrity": "sha512-uMJNiFNUXCYy/4KZaX+Ctueq+KXIWyS5Cfv2wqHNNzpV9+EhPLHUJoZKbCMY/P+IlgqTWYfpDkghZHiq5ChvEA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.2.0.tgz",
+			"integrity": "sha512-qS9p+iXpdMwCzhVRr/Ft5dMQQXB+6CxBRnpp3NDUuxYP1s/K/B1dPlIW5lKncjPUwYaKvPbpMgGGDmsosOzT8A==",
 			"requires": {
 				"@types/analytics-node": "^3.1.4",
 				"analytics-node": "^3.5.0",
@@ -269,9 +269,9 @@
 			"dev": true
 		},
 		"@types/analytics-node": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.4.tgz",
-			"integrity": "sha512-i6cqjFotMq1dEwXxyXRqnzp/HmWPCskptrVUQ1UzRIGs/zICFWM2bIJyLt6f9A9/+qE98wls1AHWPQ4WXYS0HA=="
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.5.tgz",
+			"integrity": "sha512-zSqNpyzF3hcweslf7ttqB03iZvxtymUh820SAXaFhox5Y5Qa7bYmrdOi4IW050OHrKmtq4SE4kE1XeE1mK+zrQ=="
 		},
 		"@types/bluebird": {
 			"version": "3.5.36",
@@ -583,6 +583,11 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
+		},
+		"async": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 		},
 		"async-wait-until": {
 			"version": "2.0.7",
@@ -2082,13 +2087,6 @@
 			"integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
 			"requires": {
 				"async": "^3.2.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-				}
 			}
 		},
 		"getpass": {

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
 		"redhat.vscode-yaml"
 	],
 	"dependencies": {
-		"@redhat-developer/vscode-redhat-telemetry": "^0.1.1",
+		"@redhat-developer/vscode-redhat-telemetry": "^0.2.0",
 		"@types/detect-port": "^1.3.1",
 		"@types/request-promise": "^4.1.48",
 		"@types/shelljs": "^0.8.9",


### PR DESCRIPTION
based on https://github.com/camel-tooling/vscode-camelk/pull/844 (to simplify the update)