### PR TITLE
FUSETOOLS2-1200 - disable workspace trust when launching tests

### DIFF
--- a/src/test/runTests.ts
+++ b/src/test/runTests.ts
@@ -14,8 +14,7 @@ async function main() : Promise<void> {
 		if(vscodeVersionForTest !== undefined){
 			vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersionForTest);
 		} else {
-			// FIXME: using previous version to workaround https://github.com/microsoft/vscode/issues/126636
-			vscodeExecutablePath = await downloadAndUnzipVSCode('1.57.1');
+			vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
 		}
 		console.log(`vscodeExecutablePath = ${vscodeExecutablePath}`);
 		const testWorkspace = path.resolve(__dirname, '../../../test Fixture with speci@l chars');
@@ -26,7 +25,7 @@ async function main() : Promise<void> {
 		installExtraExtension(cliPath, 'vscjava.vscode-java-debug');
 		installExtraExtension(cliPath, 'redhat.vscode-commons');
 
-		await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath, launchArgs: [testWorkspace] });
+		await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath, launchArgs: [testWorkspace, '--disable-workspace-trust'] });
 
 	} catch (err) {
 		console.error('Failed to run tests' + err);


### PR DESCRIPTION
a better workaround which allows to launch test on latest VS Code version

suggested here https://vscode-dev-community.slack.com/archives/C74CB59NE/p1625851199328400?thread_ts=1625823881.321300&cid=C74CB59NE