### PR TITLE
FUSETOOLS2-1208 - Provide CodeLens to refresh classpath dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 - Adapt Didact tutorial registration to VS Code Didact 0.4.0 updated API
 - Update default runtime version to v1.5.0
+- Provide CodeLens to refresh classpath dependencies on Camel K Java files containing a Camel K modeline
 - `resource` has been replaced by `resources` to allow providing several of them in Camel K VS Code Tasks
 
 ## 0.0.25

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Note: By default, `Auto-scroll` is checked and new entries in the log will autom
 
 To benefit from Java Language completion on standalone files, [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java) needs to be installed. An invisible project is created with a default classpath.
 
-The command `Refresh local Java classpath for Camel K standalone file based on current editor. Available with kamel 1.4+.` allows to have specfic dependencies of the opened Integration part of the classpath. For isntance, specific dependencies can be decalred as modeline.
+The command `Refresh local Java classpath for Camel K standalone file based on current editor. Available with kamel 1.4+.` refreshes specific dependencies for the classpath of the opened Integration, such as dependencies declared as part of the modeline of the file. When using a modeline to configure such dependencies, you gain a [CodeLens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup) link (`Refresh classpath dependencies`) at the top of the editor to trigger the refresh more easily.
 
 Be aware of the following limitations:
   - It requires Camel K 1.4.0

--- a/src/codelenses/ClasspathRefreshCodeLensProvider.ts
+++ b/src/codelenses/ClasspathRefreshCodeLensProvider.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as vscode from 'vscode';
+import * as extension from '../extension';
+
+const CAMELK_MODELINE_PREFIX = '// camel-k:';
+
+const CODELENS_TITLE_REFRESH_CLASSPATH = 'Refresh classpath dependencies';
+
+export class ClasspathRefreshCodeLensProvider implements vscode.CodeLensProvider {
+	
+	onDidChangeCodeLenses?: vscode.Event<void>;
+	
+	provideCodeLenses(document: vscode.TextDocument): vscode.ProviderResult<vscode.CodeLens[]> {
+		const fulltext = document.getText();
+		if(fulltext.includes(CAMELK_MODELINE_PREFIX)) {
+			const topOfDocument = new vscode.Range(0, 0, 0, 0);
+			const classPathRefreshCommand: vscode.Command = {
+				command: extension.COMMAND_ID_CLASSPATH_REFRESH,
+				title: CODELENS_TITLE_REFRESH_CLASSPATH,
+				arguments: [document.uri]
+			};
+			return [new vscode.CodeLens(topOfDocument, classPathRefreshCommand)];
+		}
+		return [];
+	}
+	
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import {checkKamelNeedsUpdate, version, handleChangeRuntimeConfiguration} from '
 import * as NewIntegrationFileCommand from './commands/NewIntegrationFileCommand';
 import { registerCamelKSchemaProvider } from './CamelKSchemaManager';
 import * as telemetry from './Telemetry';
+import { ClasspathRefreshCodeLensProvider } from './codelenses/ClasspathRefreshCodeLensProvider';
 export const DELAY_RETRY_KUBECTL_CONNECTION: number = 1000;
 
 export let mainOutputChannel: vscode.OutputChannel;
@@ -64,6 +65,8 @@ const COMMAND_ID_REMOVE = 'camelk.integrations.remove';
 export const COMMAND_ID_START_INTEGRATION = 'camelk.startintegration';
 const COMMAND_ID_OPEN_OPERATOR_LOG = 'camelk.integrations.openOperatorLog';
 export const COMMAND_ID_START_JAVA_DEBUG = 'camelk.integrations.debug.java';
+export const COMMAND_ID_CLASSPATH_REFRESH = 'camelk.classpath.refresh';
+
 export async function activate(context: vscode.ExtensionContext) {
 	stashedContext = context;
 	await telemetry.initializeTelemetry(context);
@@ -180,7 +183,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		vscode.commands.registerCommand('camelk.integrations.createNewIntegrationFile', async (...args:any[]) => { await NewIntegrationFileCommand.create(args);});
 		vscode.commands.registerCommand('camelk.integrations.selectFirstNode', () => { selectFirstItemInTree();});
-		vscode.commands.registerCommand('camelk.classpath.refresh', async (uri:vscode.Uri) => { await downloadSpecificCamelKJavaDependencies(context, uri, mainOutputChannel)});
+		vscode.commands.registerCommand(COMMAND_ID_CLASSPATH_REFRESH, async (uri:vscode.Uri) => { await downloadSpecificCamelKJavaDependencies(context, uri, mainOutputChannel)});
+		const docSelector: vscode.DocumentSelector = {
+			language: 'java',
+			scheme: 'file',
+		  }
+		vscode.languages.registerCodeLensProvider(docSelector, new ClasspathRefreshCodeLensProvider());
 		vscode.commands.registerCommand(COMMAND_ID_START_JAVA_DEBUG, async (integrationItem: TreeNode) => {
 			await StartJavaDebuggerCommand.start(integrationItem);
 			telemetry.sendCommandTracking(COMMAND_ID_START_JAVA_DEBUG);

--- a/src/test/suite/codelenses/ClasspathRefreshCodeLensProvider.test.ts
+++ b/src/test/suite/codelenses/ClasspathRefreshCodeLensProvider.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 'use strict';
+
+import { assert, expect } from "chai";
+import { ClasspathRefreshCodeLensProvider } from '../../../codelenses/ClasspathRefreshCodeLensProvider';
+import * as extension from '../../../extension';
+import * as vscode from 'vscode';
+import { getDocUri } from "../completion.util";
+ 
+ suite("Classpath refresh CodeLenses Test", function() {
+ 
+	 test("Codelens provider returns correct CodeLens", async() => {
+		const documentWithModeline = await vscode.workspace.openTextDocument({
+			language: 'java',
+			content: '// camel-k:'
+		});
+		
+		const codeLenses = await new ClasspathRefreshCodeLensProvider().provideCodeLenses(documentWithModeline);
+		checkCodeLens(codeLenses);
+	 });
+	 
+	 test("No codelenses without camel-k modeline", async() => {
+		const documentWithModeline = await vscode.workspace.openTextDocument({
+			language: 'java',
+			content: 'dummy, not camel-k modeline'
+		});
+		
+		const codeLenses: vscode.CodeLens[] | null | undefined =
+					await new ClasspathRefreshCodeLensProvider().provideCodeLenses(documentWithModeline);
+		assert.isNotNull(codeLenses);
+		expect(codeLenses as vscode.CodeLens[]).has.length(0);
+	 });
+	 
+	 test("Codelens available on a file with a modeline", async() => {
+		const docUriJava = getDocUri('MyRouteBuilderWithAdditionalDependencies.java');
+		await vscode.window.showTextDocument(docUriJava);
+		
+		const codeLenses: vscode.CodeLens[] | undefined = await vscode.commands.executeCommand('vscode.executeCodeLensProvider', docUriJava);
+		
+		checkCodeLens(codeLenses);
+	});
+
+ });
+
+function checkCodeLens(codeLenses: vscode.CodeLens[] | null | undefined) {
+	assert.isNotNull(codeLenses);
+	expect(codeLenses as vscode.CodeLens[]).has.length(1);
+	const codeLens: vscode.CodeLens = (codeLenses as vscode.CodeLens[])[0];
+	expect(codeLens.isResolved).to.be.true;
+	expect(codeLens.command?.command).to.be.equal(extension.COMMAND_ID_CLASSPATH_REFRESH);
+}


### PR DESCRIPTION

![refreshClasspathDependencies](https://user-images.githubusercontent.com/1105127/125942914-1fb8a782-bf2e-4fec-9cfc-5b29d93fd393.gif)

Currently, the command to refresh classpath dependency is provided as a
command which requires the user to know that it exists. By providing it
as codelens in this PR on top of a Camel  K modeline inside Java files, it will
spread knowledge of this capability. Also it will require less click.
