### PR TITLE
FUSETOOLS2-1108 - escape space in path to bin path

### DIFF
--- a/src/kamel.ts
+++ b/src/kamel.ts
@@ -131,9 +131,9 @@ async function kamelInternalArgs(args: string[], devMode: boolean, namespace: st
 			console.log(`command called: ${binpath} with arguments ${args}`);
 			let sr : ChildProcess;
 			if (foldername) {
-				sr = spawn(binpath, args, { cwd : foldername});
+				sr = spawn(`"${binpath}"`, args, { cwd : foldername});
 			} else {
-				sr = spawn(binpath, args);
+				sr = spawn(`"${binpath}"`, args);
 			}
 			if (sr) {
 				if (sr.stdout) {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -113,9 +113,9 @@ async function kubectlInternalArgs(args: string[], namespace: string | undefined
 			}
 			let sr : ChildProcess;
 			if (foldername) {
-				sr = spawn(binpath, args, { cwd : foldername});
+				sr = spawn(`"${binpath}"`, args, { cwd : foldername});
 			} else {
-				sr = spawn(binpath, args);
+				sr = spawn(`"${binpath}"`, args);
 			}
 			if (sr) {
 				if (sr.stdout) {


### PR DESCRIPTION
* it was done when using an exec and concatenating arguments but not
when using spawn.
* not adding test as it is tested with the Insiders job (for which the
Code instance is deployed inside a "Code - Insiders" instead of simply
"Code" folder and so containing space).

Signed-off-by: Aurélien Pupier <apupier@redhat.com>