### PR TITLE
FUSETOOLS2-1128 - Provide Start CodeLens on Camel K files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 - Adapt Didact tutorial registration to VS Code Didact 0.4.0 updated API
 - Update default runtime version to v1.5.0
-- Provide CodeLens to refresh classpath dependencies on Camel K Java files containing a Camel K modeline
+- Provide CodeLenses:
+  - to refresh classpath dependencies on Camel K Java files containing a Camel K modeline
+  - to start an integration on Camel K files using *.camelk.* file name pattern or containing a Camel K modeline
 - `resource` has been replaced by `resources` to allow providing several of them in Camel K VS Code Tasks
 - Actions related to starting an integration with resource, configmap, or secret now require kamel 1.5.0 community or 1.4.0 Red Hat
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ You can start a new Camel K integration with or without additional options such 
 * Yaml (*.yaml) (Experimental)
 
     For more information about supported languages, see [Languages](https://camel.apache.org/camel-k/latest/languages/languages.html) in the Apache Camel-K documentation.
+	
+    Note: `Start` CodeLens can also be used at the top of the editor of opened Camel K files.
 
 2. In the popup menu, select **Start Apache Camel K Integration**. 
 

--- a/src/codelenses/StartIntegrationCodeLensProvider.ts
+++ b/src/codelenses/StartIntegrationCodeLensProvider.ts
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as vscode from 'vscode';
+import * as extension from '../extension';
+
+const CAMELK_MODELINE_PREFIX_JAVA_LIKE = '// camel-k:';
+const CAMELK_MODELINE_PREFIX_YAML_LIKE = '# camel-k:';
+const CAMELK_MODELINE_PREFIX_XML_LIKE = '<!-- camel-k:';
+
+
+const CODELENS_TITLE_START_INTEGRATION = 'Start';
+
+export class StartIntegrationCodeLensProvider implements vscode.CodeLensProvider {
+
+	onDidChangeCodeLenses?: vscode.Event<void>;
+
+	provideCodeLenses(document: vscode.TextDocument): vscode.ProviderResult<vscode.CodeLens[]> {
+		const fileName = document.fileName;
+		const fulltext = document.getText();
+		if (fileName.includes('.camelk.')
+			|| fulltext.includes(CAMELK_MODELINE_PREFIX_JAVA_LIKE)
+			|| fulltext.includes(CAMELK_MODELINE_PREFIX_YAML_LIKE)
+			|| fulltext.includes(CAMELK_MODELINE_PREFIX_XML_LIKE)) {
+			const topOfDocument = new vscode.Range(0, 0, 0, 0);
+			const classPathRefreshCommand: vscode.Command = {
+				command: extension.COMMAND_ID_START_INTEGRATION,
+				title: CODELENS_TITLE_START_INTEGRATION,
+				arguments: [document.uri]
+			};
+			return [new vscode.CodeLens(topOfDocument, classPathRefreshCommand)];
+		}
+		return [];
+	}
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import * as NewIntegrationFileCommand from './commands/NewIntegrationFileCommand
 import { registerCamelKSchemaProvider } from './CamelKSchemaManager';
 import * as telemetry from './Telemetry';
 import { ClasspathRefreshCodeLensProvider } from './codelenses/ClasspathRefreshCodeLensProvider';
+import { StartIntegrationCodeLensProvider } from './codelenses/StartIntegrationCodeLensProvider';
 export const DELAY_RETRY_KUBECTL_CONNECTION: number = 1000;
 
 export let mainOutputChannel: vscode.OutputChannel;
@@ -166,6 +167,10 @@ export async function activate(context: vscode.ExtensionContext) {
 			async (...args:any[]) => {
 				await runTheFile(args);
 			}));
+		const docSelectorForPhysicalFiles: vscode.DocumentSelector = {
+				scheme: 'file'
+			}
+		vscode.languages.registerCodeLensProvider(docSelectorForPhysicalFiles, new StartIntegrationCodeLensProvider());
 	
 		// add commands to create config-map and secret objects from .properties files
 		configmapsandsecrets.registerCommands();
@@ -187,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const docSelector: vscode.DocumentSelector = {
 			language: 'java',
 			scheme: 'file',
-		  }
+		}
 		vscode.languages.registerCodeLensProvider(docSelector, new ClasspathRefreshCodeLensProvider());
 		vscode.commands.registerCommand(COMMAND_ID_START_JAVA_DEBUG, async (integrationItem: TreeNode) => {
 			await StartJavaDebuggerCommand.start(integrationItem);

--- a/src/test/suite/Utils/DeployTestUtil.ts
+++ b/src/test/suite/Utils/DeployTestUtil.ts
@@ -27,6 +27,7 @@ import { LANGUAGES_WITH_FILENAME_EXTENSIONS } from '../../../commands/NewIntegra
 import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
 import { TreeNode } from '../../../CamelKNodeProvider';
 import { UNDEPLOY_TIMEOUT, PROVIDER_POPULATED_TIMEOUT, RUNNING_TIMEOUT, DEPLOYED_TIMEOUT, EDITOR_OPENED_TIMEOUT } from '../StartIntegration.test';
+import { checkCodelensForOpenedDocument } from '../codelenses/StartIntegrationCodeLens.test';
 
 export async function cleanDeployedIntegration(telemetrySpy: sinon.SinonSpy) {
 	let deployedTreeNodes: TreeNode[] | undefined = await retrieveDeployedTreeNodes();
@@ -123,7 +124,11 @@ export async function createFile(showQuickpickStub: sinon.SinonStub<any[], any>,
 	} catch (error) {
 		assert.fail(`${integrationName}.${fileExtension} has not been opened in editor. Filename of currently opened editor: ${vscode.window.activeTextEditor?.document.fileName}`);
 	}
-	return vscode.window.activeTextEditor?.document.uri;
+	const uri = vscode.window.activeTextEditor?.document.uri;
+	
+	await checkCodelensForOpenedDocument(uri as vscode.Uri);
+	
+	return uri;
 }
 
 export function checkTelemetry(telemetrySpy: sinon.SinonSpy<any[], any>, languageExtension: string) {

--- a/src/test/suite/codelenses/ClasspathRefreshCodeLensProvider.test.ts
+++ b/src/test/suite/codelenses/ClasspathRefreshCodeLensProvider.test.ts
@@ -31,7 +31,7 @@ import { getDocUri } from "../completion.util";
 		});
 		
 		const codeLenses = await new ClasspathRefreshCodeLensProvider().provideCodeLenses(documentWithModeline);
-		checkCodeLens(codeLenses);
+		checkCodeLens(codeLenses as vscode.CodeLens[]);
 	 });
 	 
 	 test("No codelenses without camel-k modeline", async() => {
@@ -52,15 +52,16 @@ import { getDocUri } from "../completion.util";
 		
 		const codeLenses: vscode.CodeLens[] | undefined = await vscode.commands.executeCommand('vscode.executeCodeLensProvider', docUriJava);
 		
-		checkCodeLens(codeLenses);
+		checkCodeLens(codeLenses as vscode.CodeLens[]);
 	});
 
  });
 
-function checkCodeLens(codeLenses: vscode.CodeLens[] | null | undefined) {
-	assert.isNotNull(codeLenses);
-	expect(codeLenses as vscode.CodeLens[]).has.length(1);
-	const codeLens: vscode.CodeLens = (codeLenses as vscode.CodeLens[])[0];
+function checkCodeLens(codeLenses: vscode.CodeLens[]) {
+	const classpathRefreshCodeLenses = codeLenses.filter(codelens => {
+		return codelens.command?.command === extension.COMMAND_ID_CLASSPATH_REFRESH;
+	});
+	expect(classpathRefreshCodeLenses).has.length(1);
+	const codeLens: vscode.CodeLens = classpathRefreshCodeLenses[0];
 	expect(codeLens.isResolved).to.be.true;
-	expect(codeLens.command?.command).to.be.equal(extension.COMMAND_ID_CLASSPATH_REFRESH);
 }

--- a/src/test/suite/codelenses/StartIntegrationCodeLens.test.ts
+++ b/src/test/suite/codelenses/StartIntegrationCodeLens.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { assert, expect } from "chai";
+import * as extension from '../../../extension';
+import * as vscode from 'vscode';
+import { getDocUri } from '../completion.util';
+
+suite("Start Integration CodeLenses Test", function () {
+	
+	test("Codelens provider returns correct CodeLens for yaml file with modeline and without filename following pattern", async () => {
+		const doc = getDocUri('test-codelens-with-modeline.yaml');
+		await vscode.workspace.openTextDocument(doc);
+
+		await checkCodelensForOpenedDocument(doc);
+	});
+
+	test("Codelens provider returns correct CodeLens for yaml file with camelk filename pattern and without modeline", async () => {
+		const doc = getDocUri('test-codelens.camelk.yaml');
+		await vscode.workspace.openTextDocument(doc);
+
+		await checkCodelensForOpenedDocument(doc);
+	});
+
+	test("No codelenses without camel-k modeline on Java file", async () => {
+		const docUriJava = getDocUri('MyRouteBuilder.java');
+		await vscode.window.showTextDocument(docUriJava);
+
+		const codeLenses = await retrieveCodeLensOnOpenedDocument(docUriJava);
+
+		assert.isNotNull(codeLenses as vscode.CodeLens[]);
+		expect(codeLenses as vscode.CodeLens[]).has.length(0);
+	});
+
+	test("Codelens available on a Java file with a modeline", async () => {
+		const docUriJava = getDocUri('MyRouteBuilderWithAdditionalDependencies.java');
+		await vscode.window.showTextDocument(docUriJava);
+
+		await checkCodelensForOpenedDocument(docUriJava);
+	});
+
+});
+
+export async function checkCodelensForOpenedDocument(uri: vscode.Uri) {
+	const codeLenses: vscode.CodeLens[] | undefined = await retrieveCodeLensOnOpenedDocument(uri);
+	checkCodeLens(codeLenses as vscode.CodeLens[]);
+}
+
+async function retrieveCodeLensOnOpenedDocument(uri: vscode.Uri): Promise<vscode.CodeLens[] | undefined> {
+	return vscode.commands.executeCommand('vscode.executeCodeLensProvider', uri);
+}
+
+function checkCodeLens(codeLenses: vscode.CodeLens[]) {
+	const startIntegrationCodeLenses = codeLenses.filter(codelens => {
+		return codelens.command?.command === extension.COMMAND_ID_START_INTEGRATION;
+	});
+	expect(startIntegrationCodeLenses).has.length(1);
+	const codeLens: vscode.CodeLens = startIntegrationCodeLenses[0];
+	expect(codeLens.isResolved).to.be.true;
+}

--- a/test Fixture with speci@l chars/test-codelens-with-modeline.yaml
+++ b/test Fixture with speci@l chars/test-codelens-with-modeline.yaml
@@ -1,0 +1,11 @@
+# camel-k:
+- from:
+    uri: "timer:tick"
+    parameters:
+      period: "5000"
+    steps:
+      - set-body:
+          constant: "Hello Yaml !!!"
+      - transform:
+          simple: "${body.toUpperCase()}"
+      - to: "log:info"

--- a/test Fixture with speci@l chars/test-codelens.camelk.yaml
+++ b/test Fixture with speci@l chars/test-codelens.camelk.yaml
@@ -1,0 +1,10 @@
+- from:
+    uri: "timer:tick"
+    parameters:
+      period: "5000"
+    steps:
+      - set-body:
+          constant: "Hello Yaml !!!"
+      - transform:
+          simple: "${body.toUpperCase()}"
+      - to: "log:info"


### PR DESCRIPTION
![codelensToStartIntegration-yaml](https://user-images.githubusercontent.com/1105127/126296772-ae316c1f-0d63-456b-90e8-a7aee24ffd66.gif)

- available for all types of files with heuristic:
  - have *.camelk.* in file name
  - or have Camel K modeline
- currently triggers the command to "Start Integration", it lets up to the user to choose which kind of start he wants. In the future, we might decide to pick basic, or dev or debug or an associated task or the latest one used? But it is the easiest to implement as a first iteration and it already provides a lot of improvement
-  there is no test executing the codelenses. I have not found a way to do it programmatically through VS Code API. I reported this issue to provide a UI test https://issues.redhat.com/browse/FUSETOOLS2-1213
- Readme and tutorials remains valid to start an integration. That said, it might be nice to update them to include the usage of the Codelens. Reported https://issues.redhat.com/browse/FUSETOOLS2-1214 to discuss it and potentially do it in another iteration. 
For now, simply added a note as a minimal change.
