### PR TITLE
FUSETOOLS2-1236 - strip ansi code sent to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.27
 
+- Strip ANSI from kamel log to improve display in log view which doesn't support it
+
 ## 0.0.26
 
 - Adapt Didact tutorial registration to VS Code Didact 0.4.0 updated API

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,8 +497,7 @@
 		"ansi-regex": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-			"dev": true
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -984,6 +983,23 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
 			}
 		},
 		"clone-deep": {
@@ -4280,11 +4296,26 @@
 				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
 				}
 			}
 		},
@@ -4307,7 +4338,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.0"
 			}
@@ -5063,6 +5093,12 @@
 				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5086,6 +5122,15 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -385,6 +385,7 @@
 		"request": "^2.88.2",
 		"request-promise": "^4.2.6",
 		"shelljs": "^0.8.4",
+		"strip-ansi": "^6.0.0",
 		"tar": "^6.1.2",
 		"tmp": "^0.2.1",
 		"valid-filename": "^3.1.0",

--- a/src/logUtils.ts
+++ b/src/logUtils.ts
@@ -26,6 +26,8 @@ import * as config from './config';
 import * as kubectlutils from './kubectlutils';
 import { window } from 'vscode';
 
+const stripAnsi = require('strip-ansi');
+
 function getCurrentNamespace() : string {
 	let ns: string = `default`;
 	const currentNs: string | undefined = config.getNamespaceconfig();
@@ -53,12 +55,12 @@ export async function handleLogViaKamelCli(integrationName: string) : Promise<vo
 			proc.stdout.on('data', async (data: string) => {
 				if (data.length > 0) {
 					var buf = Buffer.from(data);
-					var text = buf.toString();
+					var text = stripAnsi(buf.toString());
 					if (text.indexOf(`Received hang up - stopping the main instance`) !== -1 && !closeLogViewWhenIntegrationRemoved) {
 						const title: string = panel.getTitle();
 						updateLogViewTitleToStopped(panel, title);
 					}
-					panel.addContent(buf.toString());
+					panel.addContent(text);
 				}
 			});
 		}


### PR DESCRIPTION
- the log view doesn't support ansi code (would be better to support it
but requires more work and also would be better to synchronize with VS
Code Kubernetes as the Ui was picked from there to stay consistent)
- currently using 6.0.0 instead of 7.0.0 as otherwise there is this
error preventing VS Code extension to activate:

```
Activating extension 'redhat.vscode-camelk' failed: Must use import to
load ES Module:
/home/xx/git/vscode-camelk/node_modules/strip-ansi/index.js
require() of ES modules is not supported.
require() of /home/xx/git/vscode-camelk/node_modules/strip-ansi/index.js
from /home/xx/git/vscode-camelk/out/src/logUtils.js is an ES module file
as it is a .js file whose nearest parent package.json contains "type":
"module" which defines all .js files in that package scope as ES
modules.
Instead rename index.js to end in .cjs, change the requiring code to use
import(), or remove "type": "module" from
/home/xx/git/vscode-camelk/node_modules/strip-ansi/package.json.
```

reported https://issues.redhat.com/browse/FUSETOOLS2-1237 to handle it.

relates to #386 

test to be added with https://issues.redhat.com/browse/FUSETOOLS2-682

before with Camel 1.4:
![Screenshot from 2021-07-30 09-36-36](https://user-images.githubusercontent.com/1105127/127618374-aa8becee-0e86-4911-96da-3a6f3eefd7a7.png)

after with Camel 1.4:
![Screenshot from 2021-07-30 09-36-09](https://user-images.githubusercontent.com/1105127/127618392-b5a49360-aa11-43f2-8341-871ba06ad3f2.png)
