### PR TITLE
FUSETOOLS2-1295 - fix jenkins file to use main branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,8 @@
 node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
-		git url: 'https://github.com/camel-tooling/vscode-camelk.git'
+		git url: 'https://github.com/camel-tooling/vscode-camelk.git',
+		    branch: 'main'
 	}
 
 	stage('Install requirements') {


### PR DESCRIPTION
the default branch for Jenkins git plugin is master

Signed-off-by: Aurélien Pupier <apupier@redhat.com>