### PR TITLE
FUSETOOLS2-1359 - avoid use of sudo to install global npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-          name: Install Node environment
+          name: Setup Node environment
           command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
+            sudo nvm install lts/fermium
+            sudo nvm use lts/fermium
       - run:
           name: install-vsce
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,12 @@ jobs:
             sudo apt-get install -y nodejs
       - run:
           name: install-vsce
-          command: sudo npm install -g vsce
+          command: |
+            echo $PATH
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+            npm install --prefix=$HOME/.local -g vsce
+            vsce --version
       - run:
           name: npm-ci
           command: npm ci


### PR DESCRIPTION
dependencies
on Circle CI

it was previously required, now it is causing build failures.
see https://stackoverflow.com/questions/50915469/simple-circleci-2-0-configuration-fails-for-global-npm-package-installation
for workaround

