### PR TITLE
1359 fix main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,12 @@ jobs:
             sudo apt-get install -y nodejs
       - run:
           name: install-vsce
-          command: sudo npm install -g vsce
+          command: |
+            echo $PATH
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+            npm install --prefix=$HOME/.local -g vsce
+            vsce --version
       - run:
           name: npm-ci
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             echo $PATH
             echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
-            npm install --prefix=$HOME/.local -g vsce
+            npm install --prefix=$HOME/.local -g vsce@1.103.1
             vsce --version
       - run:
           name: npm-ci

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"main": "./out/src/extension.js",
 	"contributes": {

--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -97,6 +97,6 @@ async function testCompletion(
 
 	function retrieveDestination() {
 		const context = extension.getStashedContext();
-		return JavaDependenciesManager.destinationFolderForDependencies(context);
+		return context !== undefined ? JavaDependenciesManager.destinationFolderForDependencies(context) : '';
 	}
 }


### PR DESCRIPTION
3 different things were broken in the last week so requires to mix the 3 things in same PR to have a green build:
- FUSETOOLS2-1359 - avoid use of sudo to install global npm dependencies on Circle CI. It was previously required, now it is causing build failures. See https://stackoverflow.com/questions/50915469/simple-circleci-2-0-configuration-fails-for-global-npm-package-installation for workaround
- FUSETOOLS2-1359 - fix vsce version to a compatible with node 12.x. otherwise, it is picking the latest version available which now requires node 14 
- FUSETOOLS2-1358 - use more specific activation event. It allows to build with vsce without specific flag since they introduced yet again a blocking warning which supposedly improve performance (which is pretty negligeable in our case as long running actions are launched in Promises)

- reported https://issues.redhat.com/browse/FUSETOOLS2-1361 to avoid blind updates of global npm dependencies
- reported https://issues.redhat.com/browse/FUSETOOLS2-1362 for compilation compatibility with Node 14+