### PR TITLE
Remove deprecated dependency which is no more used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,73 +30,6 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
-		"@nut-tree/libnut": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nut-tree/libnut/-/libnut-2.1.0.tgz",
-			"integrity": "sha512-aCSbURPPYC6hwJG9lT9JsjWwC8jj4Hpv2CoGIIDh+l4oPvIPTLvGTabOkcmEgz5zIxmUWAJ8kCZsnxsGE4B/EA==",
-			"dev": true,
-			"requires": {
-				"@nut-tree/libnut-darwin": "2.1.0",
-				"@nut-tree/libnut-linux": "2.1.0",
-				"@nut-tree/libnut-win32": "2.1.0"
-			}
-		},
-		"@nut-tree/libnut-darwin": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nut-tree/libnut-darwin/-/libnut-darwin-2.1.0.tgz",
-			"integrity": "sha512-gqDrieSng6wKuotx7R7SYa3Eq08+j4GNlV/4EJc+m08x2lGTUO2oyYyr30sYqGp2A+Fx8MBAZjHxJOxd9KnwkQ==",
-			"dev": true,
-			"requires": {
-				"bindings": "1.5.0",
-				"cmake-js": "6.1.0",
-				"node-addon-api": "3.0.0"
-			}
-		},
-		"@nut-tree/libnut-linux": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nut-tree/libnut-linux/-/libnut-linux-2.1.0.tgz",
-			"integrity": "sha512-g6UoVtoR6F0aN1BcWgkX40lEZzqU06/GpT2fT5i9b4kWfgcVafnrvqrd+RhG4TPfhAB7LgypNcyEWad49R/j7g==",
-			"dev": true,
-			"requires": {
-				"bindings": "1.5.0",
-				"cmake-js": "6.1.0",
-				"node-addon-api": "3.0.0"
-			}
-		},
-		"@nut-tree/libnut-win32": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nut-tree/libnut-win32/-/libnut-win32-2.1.0.tgz",
-			"integrity": "sha512-LsEmC5Jx1Oe3tJ4SrB2yUSd+tI2vIl5DQV8FjscwUZYIAauWX+cMMq6gPui8BSVJbXj+ACWYnORW2O3o7dxKqA==",
-			"dev": true,
-			"requires": {
-				"bindings": "1.5.0",
-				"cmake-js": "6.1.0",
-				"node-addon-api": "3.0.0"
-			}
-		},
-		"@nut-tree/nut-js": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@nut-tree/nut-js/-/nut-js-1.5.0.tgz",
-			"integrity": "sha512-4RC9daQkn4L49BqzlfY3qpt/HM87FhF7LXqKhQ/8g1LNvIONdlaJoZOxNvw0mJO0zQt1zsZ5bIrxhjwUGlwJGg==",
-			"dev": true,
-			"requires": {
-				"@nut-tree/libnut": "2.1.0",
-				"clipboardy": "2.0.0",
-				"opencv4nodejs-prebuilt": "5.3.0-2"
-			},
-			"dependencies": {
-				"clipboardy": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.0.0.tgz",
-					"integrity": "sha512-XbVjHMsss0giNUkp/tV/3eEAZe8i1fZTLzmPKqjE1RGIAWOTiF5D014f6R+g53ZAq0IK3cPrJXFvqE8eQjhFYQ==",
-					"dev": true,
-					"requires": {
-						"arch": "^2.1.1",
-						"execa": "^1.0.0"
-					}
-				}
-			}
-		},
 		"@redhat-developer/vscode-redhat-telemetry": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.4.2.tgz",
@@ -528,12 +461,6 @@
 				"uuid": "^3.2.1"
 			}
 		},
-		"ansi": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-			"dev": true
-		},
 		"ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -591,16 +518,6 @@
 				}
 			}
 		},
-		"are-we-there-yet": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-			"integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
-			"dev": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.0 || ^1.1.13"
-			}
-		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -644,12 +561,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -726,15 +637,6 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
 		},
 		"bl": {
 			"version": "1.2.3",
@@ -817,12 +719,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
 			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true
-		},
-		"buffer-shims": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-			"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
 			"dev": true
 		},
 		"buffers": {
@@ -1054,195 +950,6 @@
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"requires": {
 				"mimic-response": "^1.0.0"
-			}
-		},
-		"cmake-js": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.1.0.tgz",
-			"integrity": "sha512-utmukLQftpgrCpGRCaHnkv4K27HZNNFqmBl4vnvccy0xp4c1erxjFU/Lq4wn5ngAhFZmpwBPQfoKWKThjSBiwg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4",
-				"fs-extra": "^5.0.0",
-				"is-iojs": "^1.0.1",
-				"lodash": "^4",
-				"memory-stream": "0",
-				"npmlog": "^1.2.0",
-				"rc": "^1.2.7",
-				"request": "^2.54.0",
-				"semver": "^5.0.3",
-				"splitargs": "0",
-				"tar": "^4",
-				"unzipper": "^0.8.13",
-				"url-join": "0",
-				"which": "^1.0.9",
-				"yargs": "^3.6.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-					"dev": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-					"dev": true,
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"tar": {
-					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"url-join": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-					"integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"y18n": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-					"integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-					"dev": true
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.1",
-						"cliui": "^3.0.3",
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0",
-						"string-width": "^1.0.1",
-						"window-size": "^0.1.4",
-						"y18n": "^3.2.0"
-					}
-				}
 			}
 		},
 		"code-point-at": {
@@ -1527,12 +1234,6 @@
 			"requires": {
 				"callsite": "^1.0.0"
 			}
-		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -1929,12 +1630,6 @@
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
 			"integrity": "sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g=="
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
-		},
 		"filename-reserved-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -2009,36 +1704,6 @@
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
-		"fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-			"dev": true,
-			"requires": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
-			},
-			"dependencies": {
-				"jsonfile": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6",
-						"universalify": "^1.0.0"
-					}
-				},
-				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-					"dev": true
-				}
-			}
-		},
 		"fs-minipass": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -2093,19 +1758,6 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
-		},
-		"gauge": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-			"integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-			"dev": true,
-			"requires": {
-				"ansi": "^0.3.0",
-				"has-unicode": "^2.0.0",
-				"lodash.pad": "^4.1.0",
-				"lodash.padend": "^4.1.0",
-				"lodash.padstart": "^4.1.0"
-			}
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -2411,12 +2063,6 @@
 				"p-is-promise": "^1.1.0"
 			}
 		},
-		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
-		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2457,12 +2103,6 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
-		},
-		"is-iojs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-			"integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
-			"dev": true
 		},
 		"is-natural-number": {
 			"version": "4.0.1",
@@ -2834,15 +2474,6 @@
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
-		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
-			"requires": {
-				"invert-kv": "^1.0.0"
-			}
-		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -2897,24 +2528,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-		},
-		"lodash.pad": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-			"integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-			"dev": true
-		},
-		"lodash.padend": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-			"dev": true
-		},
-		"lodash.padstart": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
@@ -3070,41 +2683,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
 					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
-				}
-			}
-		},
-		"memory-stream": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-			"integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.0.26-2"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
 				}
 			}
 		},
@@ -3378,12 +2956,6 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.14.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-			"dev": true
-		},
 		"nanoid": {
 			"version": "3.1.25",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
@@ -3395,15 +2967,6 @@
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
 			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
 			"dev": true
-		},
-		"native-node-utils": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/native-node-utils/-/native-node-utils-0.2.7.tgz",
-			"integrity": "sha512-61v0G3uVxWlXHppSZGwZi+ZEIgGUKI8QvEkEJLb1GVePI7P8SBe+G747z+QMXSt4TxfgbVZP0DyobbRKYVIjdw==",
-			"dev": true,
-			"requires": {
-				"nan": "^2.13.2"
-			}
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -3434,15 +2997,6 @@
 				"json-stringify-safe": "^5.0.1",
 				"lodash.set": "^4.3.2",
 				"propagate": "^2.0.0"
-			}
-		},
-		"node-abi": {
-			"version": "2.19.3",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-			"integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
-			"dev": true,
-			"requires": {
-				"semver": "^5.4.1"
 			}
 		},
 		"node-addon-api": {
@@ -3492,12 +3046,6 @@
 				}
 			}
 		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-			"dev": true
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3531,17 +3079,6 @@
 			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
-			}
-		},
-		"npmlog": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-			"integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-			"dev": true,
-			"requires": {
-				"ansi": "~0.3.0",
-				"are-we-there-yet": "~1.0.0",
-				"gauge": "~1.2.0"
 			}
 		},
 		"nth-check": {
@@ -3596,108 +3133,11 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
-		"opencv4nodejs-prebuilt": {
-			"version": "5.3.0-2",
-			"resolved": "https://registry.npmjs.org/opencv4nodejs-prebuilt/-/opencv4nodejs-prebuilt-5.3.0-2.tgz",
-			"integrity": "sha512-l0JealJQRgSnvQHMFDP2mM/hFn8o9zOqPjljGyAzSFXzJZkR0KgXbm66Ezwjsk+IcaSo90+OUMz3D645lNUdVw==",
-			"dev": true,
-			"requires": {
-				"@types/node": ">6",
-				"nan": "^2.14.0",
-				"native-node-utils": "^0.2.7",
-				"npmlog": "^4.1.2",
-				"prebuild-install": "^5.3.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-					"dev": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"dev": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
-		},
-		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"dev": true,
-			"requires": {
-				"lcid": "^1.0.0"
-			}
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
@@ -3885,172 +3325,6 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
 				"pinkie": "^2.0.0"
-			}
-		},
-		"prebuild-install": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-			"integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
-			"dev": true,
-			"requires": {
-				"detect-libc": "^1.0.3",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^2.7.0",
-				"noop-logger": "^0.1.1",
-				"npmlog": "^4.0.1",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^3.0.3",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0",
-				"which-pm-runs": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-					"dev": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"bl": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"inherits": "^2.0.4",
-						"readable-stream": "^3.4.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						}
-					}
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"dev": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"tar-fs": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"mkdirp-classic": "^0.5.2",
-						"pump": "^3.0.0",
-						"tar-stream": "^2.1.4"
-					}
-				},
-				"tar-stream": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-					"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-					"dev": true,
-					"requires": {
-						"bl": "^4.0.3",
-						"end-of-stream": "^1.4.1",
-						"fs-constants": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^3.1.1"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "3.6.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"string_decoder": "^1.1.1",
-								"util-deprecate": "^1.0.1"
-							}
-						}
-					}
-				}
 			}
 		},
 		"prepend-http": {
@@ -4548,12 +3822,6 @@
 				"sort-keys": "^1.0.0"
 			}
 		},
-		"splitargs": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-			"integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
-			"dev": true
-		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5031,58 +4299,6 @@
 				}
 			}
 		},
-		"unzipper": {
-			"version": "0.8.14",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-			"integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
-			"dev": true,
-			"requires": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "~1.0.10",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.1.5",
-				"setimmediate": "~1.0.4"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.4.7",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-					"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-					"dev": true
-				},
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-					"integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-					"dev": true,
-					"requires": {
-						"buffer-shims": "^1.0.0",
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~0.10.x",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -5388,17 +4604,6 @@
 			"integrity": "sha512-7mGTy2Fm5VA5Go6tXnt4RrItmJnygWmlGHstWmwsYqtxEkJ5hHC4Cc59FhnaPtl/j0NlgQ+iSqPBoiQNC+J8cw==",
 			"dev": true
 		},
-		"vscode-extension-tester-native": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-native/-/vscode-extension-tester-native-3.0.2.tgz",
-			"integrity": "sha512-jWtSU9b8mxJOWHhzF18Qc4uzNvE3+2Ilw7aZ9PQzfJA9zh8C2PUYjKwhCmGaMSGJXFHuVrrRVUZ9inh03QxW/w==",
-			"dev": true,
-			"requires": {
-				"@nut-tree/nut-js": "1.5.0",
-				"clipboardy": "^2.0.0",
-				"fs-extra": "^9.0.1"
-			}
-		},
 		"vscode-kubernetes-tools-api": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/vscode-kubernetes-tools-api/-/vscode-kubernetes-tools-api-1.3.0.tgz",
@@ -5486,12 +4691,6 @@
 				"isexe": "^2.0.0"
 			}
 		},
-		"which-pm-runs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true
-		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -5527,12 +4726,6 @@
 					}
 				}
 			}
-		},
-		"window-size": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-			"dev": true
 		},
 		"workerpool": {
 			"version": "6.1.5",

--- a/package.json
+++ b/package.json
@@ -361,7 +361,6 @@
 		"tslint": "^6.1.3",
 		"typescript": "^4.3.5",
 		"vscode-extension-tester": "^4.2.3",
-		"vscode-extension-tester-native": "^3.0.2",
 		"vscode-test": "^1.6.1",
 		"vscode-uitests-tooling": "^2.2.0"
 	},


### PR DESCRIPTION
vscode-extension-tester-native

Signed-off-by: Aurélien Pupier <apupier@redhat.com>