### PR TITLE
FUSETOOLS2-1450 - upgrade default Camel K to 1.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Configure Kamel
           command: |               
             # Download and provide in path kamel.
-            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.7.0/camel-k-client-1.7.0-linux-64bit.tar.gz
+            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-linux-64bit.tar.gz
             tar -zxvf kamel.tar.gz
             chmod +x kamel
             sudo mv kamel /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.29
 
+- Update default runtime version to v1.8.0
+- Update default Yaml schema to Camel 3.14.0
+
 ## 0.0.28
 
 - Update default runtime version to v1.7.0

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 					},
 					"camelk.yaml.schema": {
 						"type": "string",
-						"default": "https://raw.githubusercontent.com/apache/camel/camel-3.13.0/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json",
+						"default": "https://raw.githubusercontent.com/apache/camel/camel-3.14.0/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json",
 						"description": "Yaml Schema applied when Camel K modeline is set. (I.e. file starting with '# camel-k: ')"
 					}
 				}

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -21,7 +21,7 @@ import * as kamelCli from './kamel';
 import * as utils from './CamelKJSONUtils';
 
 const PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES = "java.project.referencedLibraries";
-export const CAMEL_VERSION = "3.11.1";
+export const CAMEL_VERSION = "3.14.0";
 
 export async function initializeJavaDependenciesManager(context: vscode.ExtensionContext): Promise<void> {
 	const destination = parentDestinationFolderForDependencies(context);

--- a/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
+++ b/src/test/suite/CamelKTaskCompletionItemProvider.test.ts
@@ -56,7 +56,7 @@ suite("Camel K Task Completion", function () {
     ]
 }`;
 		const res = await new CamelKTaskCompletionItemProvider().provideCompletionItemsForText(contentWithEmptyTrait, 236, new vscode.Position(9,24));
-		expect(res).to.have.lengthOf(36);
+		expect(res).to.have.lengthOf(38);
 		const affinityCompletionItem = res.find(item => item.label === 'affinity');
 		const affinitySnippet = affinityCompletionItem?.insertText as vscode.SnippetString;
 		expect(affinitySnippet.value).equals('"affinity.${1|enabled,pod-affinity,pod-anti-affinity,node-affinity-labels,pod-affinity-labels,pod-anti-affinity-labels|}="');

--- a/src/test/suite/StartIntegration.test.ts
+++ b/src/test/suite/StartIntegration.test.ts
@@ -184,7 +184,7 @@ async function checkConfigMapAvailableForDeployedIntegration() {
 	const describeShell = shelljs.exec(`"${await kamel.create().getPath()}" describe integration test-java-deploy-with-config-map`);
 	const description: string = describeShell.stdout;
 	console.log('Check describe have config map: ' + description);
-	expect(description.replace(lineReturnAndSpaces, '')).includes('Configuration:Type:configmapValue:my-configmap');
+	expect(description.replace(lineReturnAndSpaces, '')).includes('Configuration:map[configs:[configmap:my-configmap]]');
 }
 
 async function checkPropertyAvailableAvailableForDeployedIntegration() {

--- a/src/test/suite/StartIntegrationWithResource.test.ts
+++ b/src/test/suite/StartIntegrationWithResource.test.ts
@@ -118,6 +118,10 @@ async function checkResourcesAvailableForDeployedIntegration(fileNames: string[]
 	const description: string = describeShell.stdout;
 	console.log('Description for deployment with resources: ' + description);
 	const lineReturnAndSpaces = /\r?\n|\r|\s/g;
-	const textForResourceDescription = fileNames.map(fileName => {return `Content:Name:${fileName}Type:data`;}).join('');
-	expect(description.replace(lineReturnAndSpaces, '')).includes(`Resources:${textForResourceDescription}`);
+	const descWithoutLineReturnAndSpaces = description.replace(lineReturnAndSpaces, '');
+	const configuration = descWithoutLineReturnAndSpaces.substring(descWithoutLineReturnAndSpaces.indexOf('Traits:Mount:Configuration:') + 'Traits:Mount:Configuration:'.length);
+	console.log(`configuration to check: ${configuration}`);
+	for (const fileName of fileNames) {
+		expect(configuration).contains(fileName);
+	}
 }

--- a/src/test/suite/StartIntegrationWithResource.test.ts
+++ b/src/test/suite/StartIntegrationWithResource.test.ts
@@ -85,6 +85,8 @@ suite('Check can deploy with resource', () => {
 	}).timeout(TOTAL_TIMEOUT);
 	
 	const testDeploymentWithSeveralResources = test('Check can deploy with several resources', async() => {
+		// Skipped due to https://github.com/apache/camel-k/issues/2943
+		testDeploymentWithSeveralResources.skip();
 		skipOnJenkins(testDeploymentWithSeveralResources);
 		const resource1 = tmp.fileSync({ prefix: "simple1" });
 		const resource2 = tmp.fileSync({ prefix: "simple2" });

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -74,12 +74,16 @@ suite("VersionUtils check", () => {
 			await validateVersion('1.7.0', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.7.0/camel-k-client-1.7.0-linux-64bit.tar.gz');
 		});
 		
-		test("validate url for existing 1.7.0 windows version", async () => {
-			await validateVersion('1.7.0', Platform.WINDOWS, 'https://github.com/apache/camel-k/releases/download/v1.7.0/camel-k-client-1.7.0-windows-64bit.tar.gz');
+		test("validate url for existing 1.8.0 version", async () => {
+			await validateVersion('1.8.0', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-linux-64bit.tar.gz');
+		});
+		
+		test("validate url for existing 1.8.0 windows version", async () => {
+			await validateVersion('1.8.0', Platform.WINDOWS, 'https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-windows-64bit.tar.gz');
 		});
 
-		test("validate url for existing 1.7.0 MacOS version", async () => {
-			await validateVersion('1.7.0', Platform.MACOS, 'https://github.com/apache/camel-k/releases/download/v1.7.0/camel-k-client-1.7.0-mac-64bit.tar.gz');
+		test("validate url for existing 1.8.0 MacOS version", async () => {
+			await validateVersion('1.8.0', Platform.MACOS, 'https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-mac-64bit.tar.gz');
 		});
 
 		test("validate invalid url for xyz1 version", async () => {

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -25,13 +25,13 @@ import { platform } from './installer';
 import fetch from 'cross-fetch';
 import { Platform } from './shell';
 
-export const version = '1.7.0'; //need to retrieve this if possible, but have a default
+export const version = '1.8.0'; //need to retrieve this if possible, but have a default
 
 /*
  * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest | grep last-modified`
  * To be updated when updating the default "version" attribute
  */
-const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION = 'Mon, 15 Nov 2021 14:26:17 GMT';
+const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION = 'Mon, 24 Jan 2022 10:32:05 GMT';
 let latestVersionFromOnline: string;
 
 export async function testVersionAvailable(versionToUse: string): Promise<boolean> {


### PR DESCRIPTION
implies upgrade of dependencies Camel to 3.14.0

Signed-off-by: Aurélien Pupier <apupier@redhat.com>