### PR TITLE
FUSETOOLS2-1456 - upgrade default Camel K to 1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Configure Kamel
           command: |               
             # Download and provide in path kamel.
-            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-linux-64bit.tar.gz
+            curl -Lo kamel.tar.gz https://github.com/apache/camel-k/releases/download/v1.8.1/camel-k-client-1.8.1-linux-64bit.tar.gz
             tar -zxvf kamel.tar.gz
             chmod +x kamel
             sudo mv kamel /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.29
 
-- Update default runtime version to v1.8.0
-- Update default Yaml schema to Camel 3.14.0
+- Update default runtime version to v1.8.1
+- Update default Yaml schema to Camel 3.14.1
 
 ## 0.0.28
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 					},
 					"camelk.yaml.schema": {
 						"type": "string",
-						"default": "https://raw.githubusercontent.com/apache/camel/camel-3.14.0/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json",
+						"default": "https://raw.githubusercontent.com/apache/camel/camel-3.14.1/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json",
 						"description": "Yaml Schema applied when Camel K modeline is set. (I.e. file starting with '# camel-k: ')"
 					},
 					"redhat.telemetry.enabled": {

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -21,7 +21,7 @@ import * as kamelCli from './kamel';
 import * as utils from './CamelKJSONUtils';
 
 const PREFERENCE_KEY_JAVA_REFERENCED_LIBRARIES = "java.project.referencedLibraries";
-export const CAMEL_VERSION = "3.14.0";
+export const CAMEL_VERSION = "3.14.1";
 
 export async function initializeJavaDependenciesManager(context: vscode.ExtensionContext): Promise<void> {
 	const destination = parentDestinationFolderForDependencies(context);

--- a/src/test/suite/StartIntegrationWithResource.test.ts
+++ b/src/test/suite/StartIntegrationWithResource.test.ts
@@ -85,7 +85,7 @@ suite('Check can deploy with resource', () => {
 	}).timeout(TOTAL_TIMEOUT);
 	
 	const testDeploymentWithSeveralResources = test('Check can deploy with several resources', async() => {
-		// Skipped due to https://github.com/apache/camel-k/issues/2943
+		// Skipped due to https://github.com/apache/camel-k/issues/3077
 		testDeploymentWithSeveralResources.skip();
 		skipOnJenkins(testDeploymentWithSeveralResources);
 		const resource1 = tmp.fileSync({ prefix: "simple1" });

--- a/src/test/suite/versionUtils.test.ts
+++ b/src/test/suite/versionUtils.test.ts
@@ -78,13 +78,19 @@ suite("VersionUtils check", () => {
 			await validateVersion('1.8.0', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-linux-64bit.tar.gz');
 		});
 		
-		test("validate url for existing 1.8.0 windows version", async () => {
-			await validateVersion('1.8.0', Platform.WINDOWS, 'https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-windows-64bit.tar.gz');
+		test("validate url for existing 1.8.1 version", async () => {
+			await validateVersion('1.8.1', Platform.LINUX, 'https://github.com/apache/camel-k/releases/download/v1.8.1/camel-k-client-1.8.1-linux-64bit.tar.gz');
+		});
+		
+		test("validate url for existing 1.8.1 windows version", async () => {
+			await validateVersion('1.8.1', Platform.WINDOWS, 'https://github.com/apache/camel-k/releases/download/v1.8.1/camel-k-client-1.8.1-windows-64bit.tar.gz');
 		});
 
-		test("validate url for existing 1.8.0 MacOS version", async () => {
-			await validateVersion('1.8.0', Platform.MACOS, 'https://github.com/apache/camel-k/releases/download/v1.8.0/camel-k-client-1.8.0-mac-64bit.tar.gz');
+		test("validate url for existing 1.8.1 MacOS version", async () => {
+			await validateVersion('1.8.1', Platform.MACOS, 'https://github.com/apache/camel-k/releases/download/v1.8.1/camel-k-client-1.8.1-mac-64bit.tar.gz');
 		});
+		
+		
 
 		test("validate invalid url for xyz1 version", async () => {
 			await invalidateVersion('xyz1', Platform.LINUX);

--- a/src/versionUtils.ts
+++ b/src/versionUtils.ts
@@ -25,13 +25,13 @@ import { platform } from './installer';
 import fetch from 'cross-fetch';
 import { Platform } from './shell';
 
-export const version = '1.8.0'; //need to retrieve this if possible, but have a default
+export const version = '1.8.1'; //need to retrieve this if possible, but have a default
 
 /*
  * Can be retrieved using `curl -i https://api.github.com/repos/apache/camel-k/releases/latest | grep last-modified`
  * To be updated when updating the default "version" attribute
  */
-const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION = 'Mon, 24 Jan 2022 10:32:05 GMT';
+const LAST_MODIFIED_DATE_OF_DEFAULT_VERSION = 'Mon, 28 Feb 2022 16:57:14 GMT';
 let latestVersionFromOnline: string;
 
 export async function testVersionAvailable(versionToUse: string): Promise<boolean> {


### PR DESCRIPTION
note that previous regression to deploy several resources has unfortunately not been fixed in Camel K 1.8.1 despite it was marked as such. Opened a new issue https://github.com/apache/camel-k/issues/3077