### PR TITLE
[FUSETOOLS2-1652] Regress strip-ansi from 7.0.1 to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -771,9 +771,9 @@
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -2549,7 +2549,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.1",
@@ -3545,9 +3545,9 @@
 			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -3589,13 +3589,13 @@
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},
@@ -5293,11 +5293,11 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-			"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"requires": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-bom": {
@@ -5796,7 +5796,7 @@
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
 						"type": "boolean",
 						"default": null,
 						"markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
-						"tags":[ "telemetry" ],
+						"tags": [
+							"telemetry"
+						],
 						"scope": "window"
 					}
 				}
@@ -397,7 +399,7 @@
 		"request": "^2.88.2",
 		"request-promise": "^4.2.6",
 		"shelljs": "^0.8.5",
-		"strip-ansi": "^7.0.1",
+		"strip-ansi": "^6.0.1",
 		"tar": "^6.1.11",
 		"tmp": "^0.2.1",
 		"valid-filename": "^3.1.0",

--- a/src/logUtils.ts
+++ b/src/logUtils.ts
@@ -53,8 +53,8 @@ export async function handleLogViaKamelCli(integrationName: string) : Promise<vo
 			proc.stdout.on('data', async (data: string) => {
 				if (data.length > 0) {
 					const buf = Buffer.from(data);
-					const stripAnsi = await import('strip-ansi');
-					const text = stripAnsi.default(buf.toString());
+					const stripAnsi = require('strip-ansi');
+					const text = stripAnsi(buf.toString());
 					if (text.indexOf(`Received hang up - stopping the main instance`) !== -1 && !closeLogViewWhenIntegrationRemoved) {
 						const title: string = panel.getTitle();
 						updateLogViewTitleToStopped(panel, title);


### PR DESCRIPTION
After users select `Follow log for running Apache Camel K Integration` log output will be frozen with `Waiting for integration simple to start...` message due to [code line ](https://github.com/camel-tooling/vscode-camelk/blob/main/src/logUtils.ts#L56)

The issue can be solved with the `strip-ansi` version downgrade from 7.0.1 to 6.0.1

Related commits:
[1] [Bump strip-ansi from 6.0.0 to 7.0.1](https://github.com/camel-tooling/vscode-camelk/commit/7284c0ac3004c2f7a411e20cf68e9aa6b6c881e4)
[2] [fixed issue with import of strip-ansi](https://github.com/camel-tooling/vscode-camelk/commit/0d78be9435ccd7925f163c5d9d63c9542ce5aa71)
[3] [FUSETOOLS2-1236 - strip ansi code sent to log](https://github.com/camel-tooling/vscode-camelk/commit/b886fcce26eb1be4f77a24bc55d8473cb301bccd)

Related issues:
[1] https://issues.redhat.com/browse/FUSETOOLS2-1236
[2] https://issues.redhat.com/browse/FUSETOOLS2-1237

Causes:
[1] https://issues.redhat.com/browse/FUSETOOLS2-1653