### PR TITLE
FUSETOOLS2-1566 - upgrade node on Circle CI to version 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - node/install:
-          node-version: '14.19.0'
+          node-version: '16.15'
       - run:
           name: install-vsce
           command: |


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>