### PR TITLE
[FUSETOOLS2-1703] strip ansi data sent to output (DevMode)

### DIFF
--- a/src/kamel.ts
+++ b/src/kamel.ts
@@ -139,7 +139,10 @@ async function kamelInternalArgs(args: string[], devMode: boolean, namespace: st
 				if (sr.stdout) {
 					sr.stdout.on('data', function (data) {
 						if (devMode && devMode === true) {
-							utils.shareMessage(extension.mainOutputChannel, `Dev Mode -- ${data}`);
+							const buf = Buffer.from(data);
+							const stripAnsi = require('strip-ansi');
+							const text = stripAnsi(buf.toString());
+							utils.shareMessage(extension.mainOutputChannel, `Dev Mode -- ${text}`);
 						}
 					});
 				}        


### PR DESCRIPTION
Hi,

During DevMode ui-tests I have found the same issue as was with FollowLogs WebView - ANSI elements remained unrecognized in the output channel 

Before fix:

![Before](https://user-images.githubusercontent.com/46084942/178483793-da94d3d0-bee7-4e48-aaf3-cdc97f0dd416.png)

After fix:

![After](https://user-images.githubusercontent.com/46084942/178483834-9b8c1128-f8c6-49d5-b1bf-ad153b7e4a22.png)

Related commits:
[1] [FUSETOOLS2-1236 - strip ansi code sent to log](https://github.com/camel-tooling/vscode-camelk/commit/b886fcce26eb1be4f77a24bc55d8473cb301bccd)

Related issues:
[1] https://issues.redhat.com/browse/FUSETOOLS2-1703
[2] https://issues.redhat.com/browse/FUSETOOLS2-1236

Added to:
[1] https://issues.redhat.com/browse/FUSETOOLS2-1653
