### PR TITLE
FUSETOOLS2-1709 - remove @types/nock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
 				"@types/glob": "^7.2.0",
 				"@types/mkdirp": "^1.0.2",
 				"@types/mocha": "^9.1.1",
-				"@types/nock": "^11.1.0",
 				"@types/node": "^18.6.2",
 				"@types/sinon": "^10.0.13",
 				"@types/sinon-chai": "^3.2.8",
@@ -537,16 +536,6 @@
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
 			"integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
 			"dev": true
-		},
-		"node_modules/@types/nock": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
-			"integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
-			"deprecated": "This is a stub types definition. nock provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"nock": "*"
-			}
 		},
 		"node_modules/@types/node": {
 			"version": "18.6.2",
@@ -8384,15 +8373,6 @@
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
 			"integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
 			"dev": true
-		},
-		"@types/nock": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
-			"integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
-			"dev": true,
-			"requires": {
-				"nock": "*"
-			}
 		},
 		"@types/node": {
 			"version": "18.6.2",

--- a/package.json
+++ b/package.json
@@ -354,7 +354,6 @@
 		"@types/glob": "^7.2.0",
 		"@types/mkdirp": "^1.0.2",
 		"@types/mocha": "^9.1.1",
-		"@types/nock": "^11.1.0",
 		"@types/node": "^18.6.2",
 		"@types/sinon": "^10.0.13",
 		"@types/sinon-chai": "^3.2.8",


### PR DESCRIPTION
given that "This is a stub types definition. nock provides its own type
definitions, so you do not need this installed."

Signed-off-by: Aurélien Pupier <apupier@redhat.com>