### PR TITLE
[FUSETOOLS2-1120] Adds VSCode Java Debugger and VSCode Language support for Java as extensionDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.32
 
+- Removed Didact extension support
 - Added extensions as dependencies
   - [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java)
   - [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.32
 
 - Removed Didact extension support
-- Added extensions as dependencies
+- Added the following extensions as dependencies. They are now installed automatically when installing VS Code Camel K instead of being optional downloads.
   - [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java)
   - [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.32
 
-- Removed Didact extension support
+- Added extensions as dependencies
+  - Language Support for Java
+  - Debugger for Java
 
 ## 0.0.31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.32
 
 - Added extensions as dependencies
-  - Language Support for Java
-  - Debugger for Java
+  - [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java)
+  - [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
 
 ## 0.0.31
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ In order to use our **Tooling for Apache Camel K** extension for VS Code, you mu
 
 * An instance of Apache Camel K running on a Kubernetes or an OpenShift cluster that is  accessible from your system on your network. You must also have Minikube (or the Kubernetes CLI) installed. See the Apache Camel K installation page for details: (https://camel.apache.org/camel-k/latest/installation/installation.html). 
 * Microsoft VS Code installed. You can get the most recent version from (https://code.visualstudio.com/) for your chosen operating system.
-* To benefit from Java Language completion on standalone files, [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java) needs to be installed.
-* To benefit from Java debug on standalone files, [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) needs to be installed.
 
 ## Installing the extension
 
@@ -257,7 +255,9 @@ Note: By default, `Auto-scroll` is checked and new entries in the log will autom
 
 ## Java language support
 
-To benefit from Java Language completion on standalone files, [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java) needs to be installed. An invisible project is created with a default classpath.
+From version 0.0.32 we provide [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java) and [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) as dependencies.
+
+With [VS Code Language support for java](https://marketplace.visualstudio.com/items?itemName=redhat.java), you will benefit from Java Language completion on standalone files. An invisible project is created with a default classpath.
 
 The command `Refresh local Java classpath for Camel K standalone file based on current editor. Available with kamel 1.4+.` refreshes specific dependencies for the classpath of the opened Integration, such as dependencies declared as part of the modeline of the file. When using a modeline to configure such dependencies, you gain a [CodeLens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup) link (`Refresh classpath dependencies`) at the top of the editor to trigger the refresh more easily.
 
@@ -268,7 +268,7 @@ Be aware of the following limitations:
   - A single classpath is provided. It means that refresh command needs to be called when switching between Integration file written in Java that does not have the same dependencies.
   - There is no progress indicator. Please be patient. The first time may take several minutes on a slow network.
   
-To benefit from Java debug on standalone files, [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) needs to be installed. To leverage it, you need to start an integration, then there are 2 solutions:
+[VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) is provided to benefit from Java debug on standalone files. To leverage it, you need to start an integration, then there are 2 solutions:
 - Right-click on integration in Integrations view, then choose `Start Java debugger on Camel K integration`.
 - Launch a `camel-k-debug` VS Code tasks and then to launch a `java` attach in debug VS Code tasks.
 

--- a/package.json
+++ b/package.json
@@ -380,7 +380,9 @@
 	},
 	"extensionDependencies": [
 		"ms-kubernetes-tools.vscode-kubernetes-tools",
-		"redhat.vscode-yaml"
+		"redhat.vscode-yaml",
+		"redhat.java",
+		"vscjava.vscode-java-debug"
 	],
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.4.3",

--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -25,7 +25,7 @@ import { fail } from 'assert';
 import * as Utils from '../Utils';
 import { waitUntil } from 'async-wait-until';
 
-const DOWNLOAD_JAVA_DEPENDENCIES_TIMEOUT = 240000;
+const DOWNLOAD_JAVA_DEPENDENCIES_TIMEOUT = 600000;
 const JAVA_EXTENSION_READINESS_TIMEOUT = 40000;
 const TOTAL_TIMEOUT = DOWNLOAD_JAVA_DEPENDENCIES_TIMEOUT + JAVA_EXTENSION_READINESS_TIMEOUT + 5000;
 

--- a/src/ui-test/tests/create_integration_file_test.ts
+++ b/src/ui-test/tests/create_integration_file_test.ts
@@ -37,8 +37,9 @@ export function createIntegrationFile(extension: string, language: string, doNex
             (await new ActivityBar().getViewControl('Explorer'))?.openView();
             await VSBrowser.instance.openResources(consts.testDir);
             VSBrowser.instance.waitForWorkbench;
-            // TODO: static wait for CamelK Windows settings through cmd.exe
-            if (process.platform == 'win32' && doNextTest.firstRun == true) {
+            // TODO previous: static wait for CamelK Windows settings through cmd.exe (process.platform == 'win32' && doNextTest.firstRun == true)
+            // TODO actual: static wait for all systems due to the issue with new dependencies (doNextTest.firstRun == true)
+            if (doNextTest.firstRun == true) {
                 this.timeout(consts.TIMEOUT_60_SECONDS);
                 doNextTest.firstRun = false;
                 await DefaultWait.sleep(consts.TIMEOUT_30_SECONDS);

--- a/src/ui-test/utils/utils.ts
+++ b/src/ui-test/utils/utils.ts
@@ -56,11 +56,7 @@ export async function prepareEmptyTestFolder(directory: string): Promise<void> {
             for (const file of files) {
                 try {
                     if (fs.existsSync(path.join(directory, file))) {
-                        fs.rm(path.join(directory, file), { recursive: true }, err => {
-                            if (err) {
-                                throw err
-                            }
-                        });
+                        fs.rmSync(path.join(directory, file), { recursive: true });
                     }
                 } catch (err) { console.log(err); }
             }

--- a/src/ui-test/utils/utils.ts
+++ b/src/ui-test/utils/utils.ts
@@ -56,7 +56,11 @@ export async function prepareEmptyTestFolder(directory: string): Promise<void> {
             for (const file of files) {
                 try {
                     if (fs.existsSync(path.join(directory, file))) {
-                        fs.unlinkSync(path.join(directory, file));
+                        fs.rm(path.join(directory, file), { recursive: true }, err => {
+                            if (err) {
+                                throw err
+                            }
+                        });
                     }
                 } catch (err) { console.log(err); }
             }


### PR DESCRIPTION
Link to issue: https://issues.redhat.com/browse/FUSETOOLS2-1120

After Aurelien investigation and a chat, we decided to put these two extensions as extensionDependencies.

I have removed/changed the mention to them in Readme and also removed the setup for those extensions on the integration tests. After searching through the code I couldn't find any more mentions/uses.