### PR TITLE
[FUSETOOLS2-1716] UI test for property mode

### DIFF
--- a/src/ui-test/tests/camelk_extension_test.ts
+++ b/src/ui-test/tests/camelk_extension_test.ts
@@ -26,7 +26,7 @@ import { DoNextTest } from '../utils/utils';
 
 export function camelkExtensionTest(extensionActivated: DoNextTest) {
 
-	describe('Extensions view', function () {
+	describe('Extensions view', async function () {
 
 		let marketplace: Marketplace;
 		let item: ExtensionsViewItem;
@@ -43,7 +43,7 @@ export function camelkExtensionTest(extensionActivated: DoNextTest) {
 			await new EditorView().closeAllEditors();
 		});
 
-		afterEach(function () {
+		afterEach(async function () {
 			if (this.currentTest?.state === 'failed' && this.id === 'required') {
 				extensionActivated.stopTest();
 			}

--- a/src/ui-test/tests/create_integration_file_test.ts
+++ b/src/ui-test/tests/create_integration_file_test.ts
@@ -25,7 +25,7 @@ import { prepareEmptyTestFolder } from '../utils/utils';
 
 export function createIntegrationFile(extension: string, language: string, doNextTest: DoNextTest) {
 
-    describe(`Create default integration file: ${consts.integrationFileName}.${extension}`, function () {
+    describe(`Create default integration file: ${consts.integrationFileName}.${extension}`, async function () {
 
         let driver: WebDriver;
 
@@ -45,13 +45,13 @@ export function createIntegrationFile(extension: string, language: string, doNex
             }
         });
 
-        beforeEach(function () {
+        beforeEach(async function () {
             if (!doNextTest.doNextTest) {
                 this.skip();
             }
         });
 
-        afterEach(function () {
+        afterEach(async function () {
             if (this.currentTest?.state === 'failed') {
                 doNextTest.stopTest();
             }

--- a/src/ui-test/tests/dev_mode_test.ts
+++ b/src/ui-test/tests/dev_mode_test.ts
@@ -37,7 +37,7 @@ import { assert } from 'chai';
 
 export function devModeTest(extension: string, language: string, doNextTest: DoNextTest) {
 
-	describe(`Dev Mode test with the integration file update`, function () {
+	describe(`Dev Mode test with the integration file update`, async function () {
 
 		let driver: WebDriver;
 
@@ -54,13 +54,13 @@ export function devModeTest(extension: string, language: string, doNextTest: DoN
 			await driver.wait(() => { return cleanOutputView(); });
 		});
 
-		beforeEach(function () {
+		beforeEach(async function () {
 			if (!doNextTest.doNextTest) {
 				this.skip();
 			}
 		});
 
-		afterEach(function () {
+		afterEach(async function () {
 			if (this.currentTest?.state === 'failed' && this.id !== 'independent') {
 				doNextTest.stopTest();
 			}
@@ -83,7 +83,7 @@ export function devModeTest(extension: string, language: string, doNextTest: DoN
 		});
 
 		it(`Initial integration output contains - ${initialLogMessage}`, async function () {
-			this.timeout(consts.TIMEOUT_30_SECONDS);
+			this.timeout(consts.TIMEOUT_60_SECONDS);
 			await driver.wait(() => { return outputViewHasText(initialLogMessage); });
 		});
 
@@ -111,7 +111,7 @@ export function devModeTest(extension: string, language: string, doNextTest: DoN
 		});
 
 		it(`Updated integration output contains - ${updatedLogMessage}`, async function () {
-			this.timeout(consts.TIMEOUT_30_SECONDS);
+			this.timeout(consts.TIMEOUT_60_SECONDS);
 			await driver.wait(() => { return outputViewHasText(updatedLogMessage); });
 		});
 

--- a/src/ui-test/uitest_suite.ts
+++ b/src/ui-test/uitest_suite.ts
@@ -16,25 +16,18 @@
  */
 'use strict';
 
-import { DefaultWait } from 'vscode-uitests-tooling';
 import { LANGUAGES_WITH_FILENAME_EXTENSIONS } from '../IntegrationConstants';
-import { basicModeWithLogsTest } from './tests/basic_mode_test';
+import { basicModeTest } from './tests/basic_mode_test';
 import { camelkExtensionTest } from './tests/camelk_extension_test';
 import { createIntegrationFile } from './tests/create_integration_file_test';
 import { devModeTest } from './tests/dev_mode_test';
+import { propertyModeTest } from './tests/property_mode_test';
 import { DoNextTest } from './utils/utils';
 
 const doNextTest = new DoNextTest();
 const extensionActivated = new DoNextTest();
 
-describe('Tooling for Apache Camel K extension', function () {
-
-    after(async function () {
-        this.timeout(11000);
-        // TODO: TMP static wait workaround for unexpected vscode-extension-tester 'afterAll' timeout on Fedora
-        // Issue: https://github.com/redhat-developer/vscode-extension-tester/issues/475
-        await DefaultWait.sleep(10000);
-    });
+describe('Tooling for Apache Camel K extension', async function () {
 
     describe(`Verify extension on Marketplace, check activation status`, async function () {
         camelkExtensionTest(extensionActivated);
@@ -42,10 +35,11 @@ describe('Tooling for Apache Camel K extension', function () {
 
     if (extensionActivated) {
         LANGUAGES_WITH_FILENAME_EXTENSIONS.forEach(async function (extension: string, language: string) {
-            describe(`${language} test pipeline`, async function () {
+            describe(`${language} test pipeline`, function () {
                 createIntegrationFile(extension, language, doNextTest);
                 devModeTest(extension, language, doNextTest);
-                basicModeWithLogsTest(extension, language, doNextTest);
+                basicModeTest(extension, language, doNextTest);
+                propertyModeTest(extension, language, doNextTest);
             });
         });
     } else {

--- a/src/ui-test/utils/waitConditions.ts
+++ b/src/ui-test/utils/waitConditions.ts
@@ -26,10 +26,10 @@ import {
     DefaultTreeItem,
     TextEditor,
     WebView,
-    Locator,
     OutputView,
     WebDriver,
-    SideBarView
+    SideBarView,
+    Locator
 } from 'vscode-extension-tester';
 import { DoNextTest, findSectionItem } from './utils';
 import { workaroundMacIssue444 } from './workarounds';
@@ -148,13 +148,13 @@ export async function webViewOpen(): Promise<WebView> {
         } else {
             return await webViewOpen();
         }
-    } catch (e) {
+    } catch (err) {
         return await webViewOpen();
     }
 }
 
 export async function webViewHasTextInWebElement(driver: WebDriver, text: string, locator: Locator = { id: 'content' }, timePeriod = 1000, timeout = 25000): Promise<boolean> {
-    const webView = await driver.wait(async () => { return webViewOpen(); }, 5000);
+    const webView = await driver.wait(async () => { return webViewOpen(); }, consts.TIMEOUT_5_SECONDS);
     try {
         return await driver.wait(async () => {
             try {
@@ -174,7 +174,7 @@ export async function webViewHasTextInWebElement(driver: WebDriver, text: string
                 return false;
             }
         }, timeout);
-    } catch (e) {
+    } catch (err) {
         await webView.switchBack();
         webView.getDriver().sleep(timePeriod);
         return false;


### PR DESCRIPTION
New property mode test added:

Test workflow:

1. Update file with properties
2. Start integration 
3. Pick start in property mode
4. Set the first property key 
5. Set the first property value
6. Pick YES to add a second property 
7. Set second property key
8. Set second property value
9.  Pick NO to start integration
10.  Check integration existence in the sidebar
11.  Follow logs
12.  Verify that pod was started
13.  Verify updated message exists in the log

[1] [FUSETOOLS2-1716](https://issues.redhat.com/browse/FUSETOOLS2-1716)