### PR TITLE
FUSETOOLS2-2061 Adapt test timeout new Completion

### DIFF
--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -30,7 +30,7 @@ const JAVA_EXTENSION_READINESS_TIMEOUT = 40000;
 const TOTAL_TIMEOUT = DOWNLOAD_JAVA_DEPENDENCIES_TIMEOUT + JAVA_EXTENSION_READINESS_TIMEOUT + 5000;
 
 // TODO: skipped on jenkins due to FUSETOOLS2-578
-suite('Should do completion in Camel K standalone files', () => {
+suite.only('Should do completion in Camel K standalone files', () => {
 	
 	const testVar = test('Completes from method for Java', async () => {
 		const docUriJava = getDocUri('MyRouteBuilder.java');

--- a/src/test/suite/completion.util.ts
+++ b/src/test/suite/completion.util.ts
@@ -27,7 +27,7 @@ export const getDocUri = (p: string) => {
 
 export async function checkExpectedCompletion(docUri: vscode.Uri, position: vscode.Position, expectedCompletion: vscode.CompletionItem) {
 	let hasExpectedCompletion = false;
-	let lastCompletionList : vscode.CompletionList | undefined;
+	let lastCompletionList: vscode.CompletionList | undefined;
 	try {
 		await waitUntil(() => {
 			// Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
@@ -42,10 +42,10 @@ export async function checkExpectedCompletion(docUri: vscode.Uri, position: vsco
 				hasExpectedCompletion = completionItemFound !== undefined;
 			});
 			return hasExpectedCompletion;
-		}, 10000, 500);
+		}, 200000, 500);
 	} catch (err) {
 		let errorMessage = '';
-		if(lastCompletionList) {
+		if (lastCompletionList) {
 			lastCompletionList.items.forEach(completion => {
 				errorMessage += completion.label.toString() + '\n';
 			});

--- a/src/test/suite/completion.util.ts
+++ b/src/test/suite/completion.util.ts
@@ -42,7 +42,7 @@ export async function checkExpectedCompletion(docUri: vscode.Uri, position: vsco
 				hasExpectedCompletion = completionItemFound !== undefined;
 			});
 			return hasExpectedCompletion;
-		}, 200000, 500);
+		}, 400000, 500);
 	} catch (err) {
 		let errorMessage = '';
 		if (lastCompletionList) {


### PR DESCRIPTION
Hi,

I think it was solved previously with https://github.com/camel-tooling/vscode-camelk/pull/1459

~~increase the timeout to 15s, let's see the test result~~
~~increase the intervals to 1s, let's see the test result~~
~~increase the timeout to 100s~~
~~increased the timeout to 200s~~
~~increased the timeout to 400s~~

I was able to get the right test result and also functionality in general work (not only in test)
But, unfortunately, that feature  works now very slowly (87-169s on local) 

Relates:
- https://issues.redhat.com/browse/FUSETOOLS2-2061

Seems now I have found the problem...