### PR TITLE
FUSETOOLS2-2061 Call refresh two times

### DIFF
--- a/src/test/suite/_completion/completion.java.test.ts
+++ b/src/test/suite/_completion/completion.java.test.ts
@@ -78,6 +78,7 @@ async function testCompletion(
 	await vscode.window.showTextDocument(doc);
 	if(refreshClasspath) {
 		await vscode.commands.executeCommand('camelk.classpath.refresh', docUri);
+		await vscode.commands.executeCommand('camelk.classpath.refresh', docUri);
 	}
 	let javaExtension: vscode.Extension<any> | undefined;
 	await waitUntil(() => {

--- a/src/test/suite/completion.util.ts
+++ b/src/test/suite/completion.util.ts
@@ -42,7 +42,7 @@ export async function checkExpectedCompletion(docUri: vscode.Uri, position: vsco
 				hasExpectedCompletion = completionItemFound !== undefined;
 			});
 			return hasExpectedCompletion;
-		}, 10000, 500);
+		}, 15000, 500);
 	} catch (err) {
 		let errorMessage = '';
 		if(lastCompletionList) {


### PR DESCRIPTION
Hi,

I have found that after the first `camelk.classpath.refresh` command config file is updated with the right dependencies, however, the `checkExpectedCompletion` function ignores it.

If dependencies are refreshed two times updated config file (SAME) will be recognized and `checkExpectedCompletion` pass without errors.

@apupier Do you have any ideas where I can search for the root of that problem?

But anyway, we can open an extra issue and unblock tests with that double refresh :thinking: 
