### PR TITLE
Remove no more needed @types/mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
 			"devDependencies": {
 				"@types/chai": "^4.3.5",
 				"@types/glob": "^8.1.0",
-				"@types/mkdirp": "^2.0.0",
 				"@types/mocha": "^10.0.1",
 				"@types/node": "^20.2.3",
 				"@types/node-fetch": "^2.6.2",
@@ -676,16 +675,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
 			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
-		},
-		"node_modules/@types/mkdirp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-2.0.0.tgz",
-			"integrity": "sha512-c/iUqMymAlxLAyIK3u5SzrwkrkyOdv1XDc91T+b5FsY7Jr6ERhUD19jJHOhPW4GD6tmN6mFEorfSdks525pwdQ==",
-			"deprecated": "This is a stub types definition. mkdirp provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"mkdirp": "*"
-			}
 		},
 		"node_modules/@types/mocha": {
 			"version": "10.0.1",
@@ -7776,15 +7765,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
 			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
-		},
-		"@types/mkdirp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-2.0.0.tgz",
-			"integrity": "sha512-c/iUqMymAlxLAyIK3u5SzrwkrkyOdv1XDc91T+b5FsY7Jr6ERhUD19jJHOhPW4GD6tmN6mFEorfSdks525pwdQ==",
-			"dev": true,
-			"requires": {
-				"mkdirp": "*"
-			}
 		},
 		"@types/mocha": {
 			"version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -356,7 +356,6 @@
 	"devDependencies": {
 		"@types/chai": "^4.3.5",
 		"@types/glob": "^8.1.0",
-		"@types/mkdirp": "^2.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^20.2.3",
 		"@types/node-fetch": "^2.6.2",


### PR DESCRIPTION
there was this warning since upgrade to mkdirp 3.0.1: `npm WARN deprecated @types/mkdirp@2.0.0: This is a stub types definition. mkdirp provides its own type definitions, so you do not need this installed.`