### PR TITLE
FUSETOOLS2-2176 - use Node 18 for build

### DIFF
--- a/.github/workflows/insider.yml
+++ b/.github/workflows/insider.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.15.x
           cache: npm
 
       - name: Install global dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.15.x
           cache: npm
 
       - name: Install global dependencies

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node('rhel8'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-lts-16'
+		def nodeHome = tool 'nodejs-lts'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 		sh "node --version"
 		sh "npm install -g typescript"


### PR DESCRIPTION
On Jenkins CI host, the ipV6 is now deactivated.
otherwise somewhere between the host and the npmjs website ipV6, a layer is not handling it correctly.