### PR TITLE
FUSETOOLS2-1888 - remove dependency on `kamel local`

### DIFF
--- a/.github/workflows/insider.yml
+++ b/.github/workflows/insider.yml
@@ -54,6 +54,9 @@ jobs:
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH
           
+      - name: Setup JBang (trusted sources)
+        run: jbang trust add https://github.com/apache/
+      
       - name: Start minikube
         uses: medyagh/setup-minikube@v0.0.14
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,10 @@ jobs:
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH
-
+      
+      - name: Setup JBang (trusted sources)
+        run: jbang trust add https://github.com/apache/
+      
       - name: Start minikube
         uses: medyagh/setup-minikube@v0.0.14
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.36
 
+- Requires jbang for java standalone completion. It allows also to get rid of internal dependency to `kamel local` which is removed from kamel 2.x.
+
 ## 0.0.35
 
 - Support `*.yml` Camel files (and not only `*.yaml`)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For more information about Camel K, be sure to check out its <a href="https://ca
 
 - An **instance of Apache Camel K** running on a Kubernetes or an OpenShift cluster
 - **Minikube** or the **Kubernetes CLI** installed. (more details at [Apache Camel K Installation](https://camel.apache.org/camel-k/latest/installation/installation.html) page)
+- For some features, [JBang](https://www.jbang.dev/documentation/guide/latest/index.html) must be available on the system command-line.
 
 ### Documentation
 

--- a/docs/content/java-support.md
+++ b/docs/content/java-support.md
@@ -4,12 +4,11 @@ From version 0.0.32 we provide [Language Support for Java(TM) by Red Hat](https:
 
 With Language Support for Java, you will benefit from Java Language completion on standalone files. An invisible project is created with a default classpath.
 
-The command `Refresh local Java classpath for Camel K standalone file based on the current editor. Available with kamel 1.4+.` refreshes specific dependencies for the classpath of the opened Integration, such as dependencies declared as part of the modeline of the file. When using a modeline to configure such dependencies, you gain a [CodeLens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup) link (`Refresh classpath dependencies`) at the top of the editor to trigger the refresh more easily.
+The command `Refresh local Java classpath for Camel K standalone file based on the current editor` refreshes specific dependencies for the classpath of the opened Integration, such as dependencies declared as part of the modeline of the file. When using a modeline to configure such dependencies, you gain a [CodeLens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup) link (`Refresh classpath dependencies`) at the top of the editor to trigger the refresh more easily.
 
 Be aware of the following **limitations**:
 
-- It requires Camel K 1.4.0
-- If mistakenly called with Camel K 1.3.2-, need to restart VS Code for basic dependencies to be available again.
+- It requires `jbang` to be available on system command-line.
 - It supports modeline dependencies notation from the local build. See [apache/camel-k#2213](https://github.com/apache/camel-k/issues/2213)
 - A single classpath is provided. It means that the refresh command needs to be called when switching between Integration file written in Java that does not have the same dependencies.
 - There is no progress indicator. Please be patient. The first time may take several minutes on a slow network.

--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
 			},
 			{
 				"command": "camelk.classpath.refresh",
-				"title": "Refresh local Java classpath for Camel K standalone file based on current editor. Available with kamel 1.4+.",
+				"shortTitle": "Refresh local Java classpath for Camel K standalone file",
+				"title": "Refresh local Java classpath for Camel K standalone file based on current editor. It requires jbang and a valid compilable file.",
 				"enablement": "editorIsOpen && editorLangId == java"
 			},
 			{

--- a/test Fixture with speci@l chars/MyRouteBuilderWithAdditionalDependencies.java
+++ b/test Fixture with speci@l chars/MyRouteBuilderWithAdditionalDependencies.java
@@ -1,9 +1,10 @@
 // camel-k: dependency=mvn:org.apache.commons:commons-math3:3.6.1
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.commons.math3.util.ArithmeticUtils;
 
 public class MyRouteBuilderWithAdditionalDependencies extends RouteBuilder{
 	public void configure() {
-        ArithmeticUt
+        ArithmeticUtils dummy;
     }
 }


### PR DESCRIPTION
- `kamel local` has been removed from kamel cli 2.x
- Adding requirement on JBang CLI to do the same action

let's start with a lot less ambitious change because after investigation it sounds moving things to a better way using JDT-LS capabilities (similar to what VS Code JBang is doing) and in VS Code language Support will be even larger than I initially thought.