### PR TITLE
Fix main branch build on CI after image change

### DIFF
--- a/.github/workflows/insider.yml
+++ b/.github/workflows/insider.yml
@@ -73,7 +73,7 @@ jobs:
           sudo mv kamel /usr/local/bin/
           kamel install
           sudo rm /usr/local/bin/kamel
-          sudo rm /usr/local/bin/kubectl
+          sudo apt-get remove -y kubectl
 
       - name: npm-ci
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           sudo mv kamel /usr/local/bin/
           kamel install
           sudo rm /usr/local/bin/kamel
-          sudo rm /usr/local/bin/kubectl
+          sudo apt-get remove -y kubectl
 
       - name: npm-ci
         run: npm ci


### PR DESCRIPTION
GitHub released a new image by default for which the way to install kubectl has been modified
https://github.com/actions/runner-images/commit/567d74923a1b56a0cac40c5f59a22b451c97eda5. Removing access from command-line is then different.