### PR TITLE
Fix refresh of classpath for some MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.37
 
+- Fix Java standalone support on MacOS
+
 ## 0.0.36
 
 - Requires jbang for java standalone completion. It allows also to get rid of internal dependency to `kamel local` which is removed from kamel 2.x.

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -51,7 +51,12 @@ export async function downloadSpecificCamelKJavaDependencies(
 		// replace of backslash by slash is a workaround to CAMEL-20033
 		const command = `jbang camel@apache/camel dependency copy --output-directory="${destination}" "${uri.fsPath.replace(/\\/g,'/')}"`;
 		try {
-			execSync(command);
+			if (vscode.workspace.workspaceFolders != undefined) {
+				// In some not clearly defined cases on MacOS, the current working directory must be provided
+				execSync(command, {cwd: (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0].uri.fsPath});
+			} else {
+				execSync(command);
+			}
 			triggerRefreshOfJavaClasspath(context);
 		} catch(error) {
 			utils.shareMessage(mainOutputChannel, `Error while trying to refresh Java classpath based on file ${uri.fsPath}:\n${error}`);


### PR DESCRIPTION
For not clearly defined reasons (that we are able to find), on some MacOS machines, the current working directory used by default by Node.js execSync method is not picked by correctly by Camel Jbang. Using the workspace folder is workarounding the issue.
In regular cases, there will be a workspace folder available.

fix #1698