### PR TITLE
Fix main branch

### DIFF
--- a/.github/workflows/OtherOSes.yml
+++ b/.github/workflows/OtherOSes.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        version: [max] # [x.x.x | latest | max]
+        version: ["1.85.2"] # [x.x.x | latest | max]
         type: [stable] # [stable | insider]
       fail-fast: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [max] # [x.x.x | latest | max]
+        version: ["1.85.2"] # [x.x.x | latest | max]
         type: [stable] # [stable | insider]
       fail-fast: false
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For more information about Camel K, be sure to check out its <a href="https://ca
 - An **instance of Apache Camel K** running on a Kubernetes or an OpenShift cluster
 - **Minikube** or the **Kubernetes CLI** installed. (more details at [Apache Camel K Installation](https://camel.apache.org/camel-k/latest/installation/installation.html) page)
 - For some features, [JBang](https://www.jbang.dev/documentation/guide/latest/index.html) must be available on the system command-line.
+- VS Code up to 1.85 is recommended. One test related to completion on Java standalone files with 1.86.x is failing but we have not found steps to reproduce manually, neither how to fix it so far.
 
 ### Documentation
 

--- a/src/test/suite/CamelKSchemaManager.test.ts
+++ b/src/test/suite/CamelKSchemaManager.test.ts
@@ -55,6 +55,6 @@ suite('Test Camel K Schema Manager', function () {
 		await waitUntil(() => {
 			const schema: string | undefined = CamelKSchemaManager.requestYamlSchemaContentCallback(CAMELK_SCHEMA_URI_PREFIX);
 			return schema?.includes('# Visual Studio extension to support Apache Camel K');
-		});
+		}, 5000, 1000);
 	});
 });


### PR DESCRIPTION
* we need to space out request to GitHub to retrieve the file content against we want to check
* Test with 1.85.2 instead of latest 1.86. It is failing with 1.86.x. Cannot reproduce manually even if behavior seems inconsistent, it is always possible to refresh classpath several times and/or close/reopen and it finishes to work. To unblock main branch, test with 1.85 and add a note in readme. Reported https://issues.redhat.com/browse/FUSETOOLS2-2311 to tackle it in another phase.