### PR TITLE
FUSETOOLS2-2352 - Mitigate .camel.jbang folder created at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 
 ## 0.0.39
 
+- Mitigate issue of a created `.camel.jbang` folder when the extension is starting. It is now occuring only on MacOS. No more on Linux and Windows. This is a workaround on MacOS related to https://github.com/camel-tooling/vscode-camelk/issues/1698 that we cannot remove for now.
+
 ## 0.0.38
 
 - Update default runtime version to v2.2.0

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { platform } from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as utils from './CamelKJSONUtils';
@@ -51,7 +52,7 @@ export async function downloadSpecificCamelKJavaDependencies(
 		// replace of backslash by slash is a workaround to CAMEL-20033
 		const command = `jbang camel@apache/camel dependency copy --output-directory="${destination}" "${uri.fsPath.replace(/\\/g,'/')}"`;
 		try {
-			if (vscode.workspace.workspaceFolders != undefined) {
+			if (platform() === 'darwin' && vscode.workspace.workspaceFolders != undefined) {
 				// In some not clearly defined cases on MacOS, the current working directory must be provided
 				execSync(command, {cwd: (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0].uri.fsPath});
 			} else {


### PR DESCRIPTION
@djelinek Could you test on Mac that the completion of Java standalone files is still working on MacOS please?

EDIT: please try https://github.com/camel-tooling/vscode-camelk/pull/1794 first, if the other is working, no need to try this one