### PR TITLE
Fusetools2 2352 Use Extension storage folder as working directory for Camel JBang working directory on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.39
 
 - Update default runtime version to v2.3.0
-- Mitigate issue of a created `.camel.jbang` folder when the extension is starting. It is now occuring only on MacOS. No more on Linux and Windows. This is a workaround on MacOS related to https://github.com/camel-tooling/vscode-camelk/issues/1698 that we cannot remove for now.
+- Avoid creating `.camel.jbang` folder at workspace root when the extension is starting
 
 ## 0.0.38
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-camelk" extension will be documented in this 
 ## 0.0.39
 
 - Update default runtime version to v2.3.0
+- Mitigate issue of a created `.camel.jbang` folder when the extension is starting. It is now occuring only on MacOS. No more on Linux and Windows. This is a workaround on MacOS related to https://github.com/camel-tooling/vscode-camelk/issues/1698 that we cannot remove for now.
 
 ## 0.0.38
 

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { platform } from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as utils from './CamelKJSONUtils';
@@ -51,7 +52,7 @@ export async function downloadSpecificCamelKJavaDependencies(
 		// replace of backslash by slash is a workaround to CAMEL-20033
 		const command = `jbang camel@apache/camel dependency copy --output-directory="${destination}" "${uri.fsPath.replace(/\\/g,'/')}"`;
 		try {
-			if (vscode.workspace.workspaceFolders != undefined) {
+			if (platform() === 'darwin' && vscode.workspace.workspaceFolders != undefined) {
 				// In some not clearly defined cases on MacOS, the current working directory must be provided
 				execSync(command, {cwd: (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0].uri.fsPath});
 			} else {

--- a/src/JavaDependenciesManager.ts
+++ b/src/JavaDependenciesManager.ts
@@ -52,9 +52,10 @@ export async function downloadSpecificCamelKJavaDependencies(
 		// replace of backslash by slash is a workaround to CAMEL-20033
 		const command = `jbang camel@apache/camel dependency copy --output-directory="${destination}" "${uri.fsPath.replace(/\\/g,'/')}"`;
 		try {
-			if (platform() === 'darwin' && vscode.workspace.workspaceFolders != undefined) {
-				// In some not clearly defined cases on MacOS, the current working directory must be provided
-				execSync(command, {cwd: (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0].uri.fsPath});
+			if (platform() === 'darwin' && context.storageUri != undefined) {
+				// In some not clearly defined cases on MacOS, a current working directory must be provided
+				await vscode.workspace.fs.createDirectory(context.storageUri);
+				execSync(command, {cwd: context.storageUri.fsPath});
 			} else {
 				execSync(command);
 			}


### PR DESCRIPTION
@djelinek Can you try this PR on MacOS please?