### PR TITLE
FUSETOOLS2-2311 - fix tests with VS Code 1.86+

### DIFF
--- a/.github/workflows/OtherOSes.yml
+++ b/.github/workflows/OtherOSes.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        version: ["1.85.2"] # [x.x.x | latest | max]
+        version: ["1.85.2", max] # [x.x.x | latest | max]
         type: [stable] # [stable | insider]
       fail-fast: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: ["1.85.2"] # [x.x.x | latest | max]
+        version: ["1.85.2", max] # [x.x.x | latest | max]
         type: [stable] # [stable | insider]
       fail-fast: false
 

--- a/src/test/suite/completion.util.ts
+++ b/src/test/suite/completion.util.ts
@@ -35,7 +35,8 @@ export async function checkExpectedCompletion(docUri: vscode.Uri, position: vsco
 				const actualCompletionList = value as vscode.CompletionList;
 				lastCompletionList = actualCompletionList;
 				const completionItemFound = actualCompletionList.items.find(completion => {
-					return completion.label.toString() === expectedCompletion.label.toString()
+					return (completion.label.toString() === expectedCompletion.label.toString()
+							|| completion.label.toString() === (expectedCompletion.label as vscode.CompletionItemLabel).label)
 						&& completion.documentation === expectedCompletion.documentation
 						&& (expectedCompletion.insertText === undefined || completion.insertText === expectedCompletion.insertText);
 				});


### PR DESCRIPTION
on Windows and Mac, the returned completion has a different structure in some cases starting with VS Code 1.86+.